### PR TITLE
Bump Juice Shop version to hotfix 12.10.1

### DIFF
--- a/helm/multi-juicer/values.yaml
+++ b/helm/multi-juicer/values.yaml
@@ -82,7 +82,7 @@ juiceShop:
   maxInstances: 10
   # -- Juice Shop Image to use
   image: bkimminich/juice-shop
-  tag: v12.10.0
+  tag: v12.10.1
   # -- Change the key when hosting a CTF event. This key gets used to generate the challenge flags. See: https://pwning.owasp-juice.shop/part1/ctf.html#overriding-the-ctfkey
   ctfKey: "zLp@.-6fMW6L-7R3b!9uR_K!NfkkTr"
   # -- Specify a custom Juice Shop config.yaml. See the JuiceShop Config Docs for more detail: https://pwning.owasp-juice.shop/part1/customization.html#yaml-configuration-file


### PR DESCRIPTION
(previous version could not reissue flag notifications in CTF mode)