### PR TITLE
fix: adds semverCompare check to cleanup cronjob

### DIFF
--- a/helm/multi-juicer/templates/cleanup-cron-job.yaml
+++ b/helm/multi-juicer/templates/cleanup-cron-job.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.juiceShopCleanup.enabled -}}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: batch/v1
+{{- else -}}
+apiVersion: batch/v1beta1
+{{- end }}
 kind: CronJob
 metadata:
   name: 'cleanup-job'


### PR DESCRIPTION
Hi there

First of all: thank you SO MUCH for your work and efforts to keep multi-juicer going! It helped us on our way to make developers aware about security issues in a fun, challenging and gamified way :)

When deploying the latest version to our sandbox clusters, i noticed that you updated the `apiVersion` for the `cleanup-job`. As we are not running the latest version of k8s (we run 1.19 at the time of writing), the deployment failed due to `batch/v1` only being available from version 1.21.

This PR adds a semverCompare to `cleanup-job` to make sure the application can be deployed to versions below 1.21 too.

If you feel this is not necessary to land on the master branch, feel free to decline the PR, no offense taken ;)

Cheers
Stefan