### PR TITLE
Add information on CTF events

### DIFF
--- a/guides/production-notes/production-notes.md
+++ b/guides/production-notes/production-notes.md
@@ -6,7 +6,7 @@ To ensure MultiJuicer runs as smoothly during your CTF's / trainings / workshops
 2. As you are running this with https (right?), you should set `balancer.cookie.secure` to `true`. This marks the cookie used to associate a browser with a team to transmitted via https only.
 3. Make sure the value you have configured for `juiceShop.maxInstances` fits your CTF / training / whatever you are running. The default is set to only allow 10 instances. Set to -1 to remove any restrictions.
 4. Set `balancer.replicas` to at least 2, so that you have at least one fall back JuiceBalancer when one crashes or the node it lives on goes down.
-5. When running a CTF with JuiceShop challenge flags, make sure to change `juiceShop.ctfKey` from the default. Otherwise users will be able to generate their own flags relatively easily. See
+5. When running a CTF with JuiceShop challenge flags, make sure to change `juiceShop.ctfKey` from the default. Otherwise users will be able to generate their own flags relatively easily. Additionally, include the `juiceShop.nodeEnv` value and specify it as "ctf". This way, it will generate flags for the CTF event. The default behavior is to not generate them.
 6. When using prometheus metrics, e.g. when you have followed the [Monitoring SetUp Guide](https://github.com/juice-shop/multi-juicer/blob/main/guides/monitoring-setup/monitoring.md) you'll want to change `balancer.metrics.basicAuth.password` to a non default values. Otherwise users can use the default value to access the technical metrics of the JuiceBalancer pods.
 
 ## TLDR
@@ -25,5 +25,6 @@ balancer:
 
 juiceShop:
   maxInstances: 42
+  nodeEnv: "ctf"
   ctfKey: "DONT_LET_ME_FIND_YOU_USING_THIS_EXACT_VALUE"
 ```


### PR DESCRIPTION
Added more information in the production notes on holding a CTF event. The default behavior of the application is to not generate CTF flags.