### PR TITLE
Add additional labels, annotations and ingress improvements

### DIFF
--- a/helm/multi-juicer/Chart.yaml
+++ b/helm/multi-juicer/Chart.yaml
@@ -28,10 +28,10 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 6.0.0
+version: 6.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 6.0.0
+appVersion: 6.0.1
 
 dependencies: []

--- a/helm/multi-juicer/templates/juice-balancer/config-map.yaml
+++ b/helm/multi-juicer/templates/juice-balancer/config-map.yaml
@@ -38,6 +38,7 @@ data:
         "volumeMounts": {{ .Values.juiceShop.volumeMounts | toJson }},
         "affinity": {{ .Values.juiceShop.affinity | toJson }},
         "tolerations": {{ .Values.juiceShop.tolerations | toJson }},
-        "runtimeClassName": {{ .Values.juiceShop.runtimeClassName | toJson }}
+        "runtimeClassName": {{ .Values.juiceShop.runtimeClassName | toJson }},
+        "additionalAnnotations": {{ .Values.juiceShop.additionalAnnotations | toJson }}
       }
     }

--- a/helm/multi-juicer/templates/juice-balancer/deployment.yaml
+++ b/helm/multi-juicer/templates/juice-balancer/deployment.yaml
@@ -14,6 +14,9 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/juice-balancer/config-map.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/juice-balancer/secret.yaml") . | sha256sum }}
+        {{- with .Values.balancer.additionalAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "multi-juicer.juice-balancer.labels" . | nindent 8 }}
     spec:

--- a/helm/multi-juicer/templates/juice-balancer/ingress.yaml
+++ b/helm/multi-juicer/templates/juice-balancer/ingress.yaml
@@ -12,6 +12,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+{{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- end }}  
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}

--- a/helm/multi-juicer/templates/juice-balancer/servicemonitor.yaml
+++ b/helm/multi-juicer/templates/juice-balancer/servicemonitor.yaml
@@ -5,6 +5,9 @@ metadata:
   name: juice-balancer
   labels:
     {{ include "multi-juicer.juice-balancer.labels" . | nindent 4 }}
+    {{- with .Values.balancer.metrics.serviceMonitor.additionalLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/helm/multi-juicer/templates/juice-shop/servicemonitor.yaml
+++ b/helm/multi-juicer/templates/juice-shop/servicemonitor.yaml
@@ -5,6 +5,9 @@ metadata:
   name: juice-shops
   labels:
     {{- include "multi-juicer.juice-shop.labels" . | nindent 4 }}
+    {{- with .Values.balancer.metrics.serviceMonitor.additionalLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   targetLabels:
     - team

--- a/helm/multi-juicer/values.yaml
+++ b/helm/multi-juicer/values.yaml
@@ -146,7 +146,8 @@ juiceShop:
   affinity: {}
   # -- Optional Configure kubernetes toleration for the created JuiceShops (see: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
   tolerations: []
-
+  # -- Optional Additional annotations for the Juice Shop pods.
+  additionalAnnotations: {}
   # -- Optional Can be used to configure the runtime class for the JuiceShop pods to add an additional layer of isolation to reduce the impact of potential container escapes. (see: https://kubernetes.io/docs/concepts/containers/runtime-class/)
   runtimeClassName: null
 

--- a/helm/multi-juicer/values.yaml
+++ b/helm/multi-juicer/values.yaml
@@ -7,9 +7,9 @@ nodeSelector: {}
 
 ingress:
   enabled: false
+  ingressClassName: nginx
   annotations:
     {}
-    # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
     - host: multi-juicer.local

--- a/helm/multi-juicer/values.yaml
+++ b/helm/multi-juicer/values.yaml
@@ -63,6 +63,8 @@ balancer:
   tolerations: []
   # -- If set to true this skips setting ownerReferences on the teams JuiceShop Deployment and Services. This lets MultiJuicer run in older kubernetes cluster which don't support the reference type or the app/v1 deployment type
   skipOwnerReference: false
+  # -- Optional Additional annotations for the balancer pods.
+  additionalAnnotations: {}
   metrics:
     # -- enables prometheus metrics for the balancer. If set to true you should change the prometheus-scraper password
     enabled: true

--- a/helm/multi-juicer/values.yaml
+++ b/helm/multi-juicer/values.yaml
@@ -74,6 +74,9 @@ balancer:
     serviceMonitor:
       # -- If true, creates a Prometheus Operator ServiceMonitor (also requires metrics.enabled to be true). This will also deploy a servicemonitor which monitors metrics from the Juice Shop instances
       enabled: false
+      # -- Allows to add additional labels. The Prometheus Operator can be adjusted to look for specific labels in ServiceMonitors.
+      # -- If you use the Kube-Prometheus-Stack Helm-Chart, the default label looked for is `release=<Kube-Prometheus-Release-Name>
+      additionalLabels: {}
     basicAuth:
       username: prometheus-scraper
       # -- Should be changed when metrics are enabled.

--- a/juice-balancer/config/config.json
+++ b/juice-balancer/config/config.json
@@ -37,6 +37,7 @@
       }
     },
     "tolerations": [],
-    "affinity": {}
+    "affinity": {},
+    "additionalAnnotations": {}
   }
 }

--- a/juice-balancer/src/kubernetes.js
+++ b/juice-balancer/src/kubernetes.js
@@ -58,6 +58,7 @@ const createDeploymentForTeam = async ({ team, passcodeHash }) => {
             'app.kubernetes.io/instance': `juice-shop-${get('deploymentContext')}`,
             'app.kubernetes.io/part-of': 'multi-juicer',
           },
+          annotations: get('juiceShop.additionalAnnotations')
         },
         spec: {
           automountServiceAccountToken: false,

--- a/juice-balancer/src/kubernetes.js
+++ b/juice-balancer/src/kubernetes.js
@@ -58,7 +58,7 @@ const createDeploymentForTeam = async ({ team, passcodeHash }) => {
             'app.kubernetes.io/instance': `juice-shop-${get('deploymentContext')}`,
             'app.kubernetes.io/part-of': 'multi-juicer',
           },
-          annotations: get('juiceShop.additionalAnnotations')
+          annotations: get('juiceShop.additionalAnnotations'),
         },
         spec: {
           automountServiceAccountToken: false,


### PR DESCRIPTION
Added

- additionalAnnotations for pods of balancer and juice-shop (useful to add them into service meshes)
- additionalLabels for ServiceMonitors (useful for adding them to kube-prometheus stack)
- ingressClassName for ingress class