### PR TITLE
Add startup probe to juice-shop pod

### DIFF
--- a/juice-balancer/src/kubernetes.js
+++ b/juice-balancer/src/kubernetes.js
@@ -109,6 +109,14 @@ const createDeploymentForTeam = async ({ team, passcodeHash }) => {
                 initialDelaySeconds: 30,
                 periodSeconds: 15,
               },
+              startupProbe: {
+                httpGet: {
+                  path: '/rest/admin/application-version',
+                  port: 3000,
+                },
+                failureThreshold: 30,
+                periodSeconds: 10,
+              },
               volumeMounts: [
                 {
                   name: 'juice-shop-config',

--- a/juice-balancer/src/kubernetes.js
+++ b/juice-balancer/src/kubernetes.js
@@ -114,8 +114,8 @@ const createDeploymentForTeam = async ({ team, passcodeHash }) => {
                   path: '/rest/admin/application-version',
                   port: 3000,
                 },
-                failureThreshold: 30,
-                periodSeconds: 10,
+                failureThreshold: 150,
+                periodSeconds: 2,
               },
               volumeMounts: [
                 {


### PR DESCRIPTION
This adds  a startup probe with the same liveness checks to cover the worst case startup time. On slower nodes the container does not come up if it takes too long to during startup.