### PR TITLE
Update guides to point to Github Container Registry

### DIFF
--- a/guides/aws/aws.md
+++ b/guides/aws/aws.md
@@ -32,10 +32,7 @@ kubectl config current-context
 ## Step 2. Installing MultiJuicer via helm
 
 ```sh
-# You'll need to add the multi-juicer helm repo to your helm repos
-helm repo add multi-juicer https://juice-shop.github.io/multi-juicer/
-
-helm install multi-juicer multi-juicer/multi-juicer
+helm install multi-juicer oci://ghcr.io/juice-shop/multi-juicer/helm/multi-juicer
 
 # kubernetes will now spin up the pods
 # to verify every thing is starting up, run:

--- a/guides/azure/azure.md
+++ b/guides/azure/azure.md
@@ -26,10 +26,7 @@ kubectl config current-context
 ## Step 2. Installing MultiJuicer via helm
 
 ```bash
-# You'll need to add the multi-juicer helm repo to your helm repos
-helm repo add multi-juicer https://juice-shop.github.io/multi-juicer/
-
-helm install multi-juicer multi-juicer/multi-juicer
+helm install multi-juicer oci://ghcr.io/juice-shop/multi-juicer/helm/multi-juicer
 
 # kubernetes will now spin up the pods
 # to verify every thing is starting up, run:

--- a/guides/digital-ocean/digital-ocean.md
+++ b/guides/digital-ocean/digital-ocean.md
@@ -26,10 +26,7 @@ kubectl config current-context
 ## Step 2. Installing MultiJuicer via helm
 
 ```bash
-# You'll need to add the multi-juicer helm repo to your helm repos
-helm repo add multi-juicer https://juice-shop.github.io/multi-juicer/
-
-helm install multi-juicer multi-juicer/multi-juicer
+helm install multi-juicer oci://ghcr.io/juice-shop/multi-juicer/helm/multi-juicer
 
 # kubernetes will now spin up the pods
 # to verify every thing is starting up, run:

--- a/guides/k8s/k8s.md
+++ b/guides/k8s/k8s.md
@@ -20,10 +20,7 @@ kubectl cluster-info
 ## Step 2. Installing MultiJuicer via helm
 
 ```bash
-# You'll need to add the multi-juicer helm repo to your helm repos
-helm repo add multi-juicer https://juice-shop.github.io/multi-juicer/
-
-helm install multi-juicer multi-juicer/multi-juicer
+helm install multi-juicer oci://ghcr.io/juice-shop/multi-juicer/helm/multi-juicer
 
 # kubernetes will now spin up the pods
 # to verify every thing is starting up, run:

--- a/guides/monitoring-setup/monitoring.md
+++ b/guides/monitoring-setup/monitoring.md
@@ -25,8 +25,5 @@ echo "Installing loki/promtail"
 helm --namespace monitoring upgrade --install promtail grafana/promtail --version 3.0.4 --set "config.lokiAddress=http://loki:3100/loki/api/v1/push" --set="serviceMonitor.enabled=true"
 
 echo "Installing MultiJuicer"
-helm repo add multi-juicer https://juice-shop.github.io/multi-juicer/
-
-# for helm >= 3
-helm install multi-juicer multi-juicer/multi-juicer --set="balancer.metrics.enabled=true" --set="balancer.metrics.dashboards.enabled=true" --set="balancer.metrics.serviceMonitor.enabled=true"
+helm install multi-juicer oci://ghcr.io/juice-shop/multi-juicer/helm/multi-juicer --set="balancer.metrics.enabled=true" --set="balancer.metrics.dashboards.enabled=true" --set="balancer.metrics.serviceMonitor.enabled=true"
 ```

--- a/guides/openshift/openshift.md
+++ b/guides/openshift/openshift.md
@@ -24,10 +24,7 @@ oc new-project multi-juicer
 ## Step 2. Installing MultiJuicer via helm
 
 ```bash
-# You'll need to add the multi-juicer helm repo to your helm repos
-helm repo add multi-juicer https://juice-shop.github.io/multi-juicer/
-
-helm install multi-juicer multi-juicer/multi-juicer ./multi-juicer/helm/multi-juicer/
+helm install multi-juicer oci://ghcr.io/juice-shop/multi-juicer/helm/multi-juicer
 ```
 
 ## Step 3. Verify the app is running correctly


### PR DESCRIPTION
What first lead me down the wrong path in #198 was that the guides still reference the GitHub Pages-based Helm chart. This PR simply updates the references in the guides to point to the OCI-based registry to avoid others being lead astray.