### PR TITLE
Updating Monitoring guide to use newest helm charts and add config required by the version bump

### DIFF
--- a/guides/monitoring-setup/loki-monitoring-config.yaml
+++ b/guides/monitoring-setup/loki-monitoring-config.yaml
@@ -1,0 +1,58 @@
+loki:
+  storage:
+    type: filesystem
+  storage_config:
+    filesystem:
+      directory: /tmp/loki/
+  commonConfig:
+    replication_factor: 1
+  schemaConfig:
+    configs:
+      - from: "2024-04-01"
+        store: tsdb
+        object_store: filesystem
+        schema: v13
+        index:
+          prefix: loki_index_
+          period: 24h
+  ruler:
+    enable_api: true
+
+chunksCache:
+  enabled: false
+
+monitoring:
+  serviceMonitor:
+    enabled: true
+
+deploymentMode: SingleBinary
+
+singleBinary:
+  replicas: 1
+
+# Zero out replica counts of other deployment modes
+backend:
+  replicas: 0
+read:
+  replicas: 0
+write:
+  replicas: 0
+
+ingester:
+  replicas: 0
+querier:
+  replicas: 0
+queryFrontend:
+  replicas: 0
+queryScheduler:
+  replicas: 0
+distributor:
+  replicas: 0
+compactor:
+  replicas: 0
+indexGateway:
+  replicas: 0
+bloomCompactor:
+  replicas: 0
+bloomGateway:
+  replicas: 0

--- a/guides/monitoring-setup/prometheus-operator-config.yaml
+++ b/guides/monitoring-setup/prometheus-operator-config.yaml
@@ -11,3 +11,7 @@ grafana:
       type: loki
       access: proxy
       url: "http://loki:3100"
+      jsonData:
+        httpHeaderName1: 'X-Scope-OrgID'
+      secureJsonData:
+        httpHeaderValue1: 'multijuicer'

--- a/helm/multi-juicer/dashboards/instances.json
+++ b/helm/multi-juicer/dashboards/instances.json
@@ -1235,7 +1235,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "increase(http_requests_count{app.kubernetes.io/name=\"juiceshop\", team=\"$team\"}[1m])",
+          "expr": "increase(http_requests_count{app=\"juiceshop\", team=\"$team\"}[1m])",
           "interval": "1m",
           "legendFormat": "{{status_code}}",
           "refId": "A"
@@ -1921,7 +1921,7 @@
       },
       "targets": [
         {
-          "expr": "{app.kubernetes.io/name=\"juice-shop\", team=\"$team\"}",
+          "expr": "{app=\"juice-shop\", team=\"$team\"}",
           "refId": "A"
         }
       ],

--- a/helm/multi-juicer/tests/__snapshot__/multijuicer_test.yaml.snap
+++ b/helm/multi-juicer/tests/__snapshot__/multijuicer_test.yaml.snap
@@ -2209,7 +2209,7 @@ full values render out correctly:
               "steppedLine": false,
               "targets": [
                 {
-                  "expr": "increase(http_requests_count{app.kubernetes.io/name=\"juiceshop\", team=\"$team\"}[1m])",
+                  "expr": "increase(http_requests_count{app=\"juiceshop\", team=\"$team\"}[1m])",
                   "interval": "1m",
                   "legendFormat": "{{status_code}}",
                   "refId": "A"
@@ -2895,7 +2895,7 @@ full values render out correctly:
               },
               "targets": [
                 {
-                  "expr": "{app.kubernetes.io/name=\"juice-shop\", team=\"$team\"}",
+                  "expr": "{app=\"juice-shop\", team=\"$team\"}",
                   "refId": "A"
                 }
               ],


### PR DESCRIPTION
Updated the versions in the monitoring guide to the newest available so it would work on an up to date kubernetes cluster. Added a minimal config file for loki which was required for the updated helm chart. 

I also changed the label selector for kubernetes app names as they are exported as "app" instead of "app.kubernetes.io/name" nowadays. 