### PR TITLE
Fix ingress.yaml service/port, make custom domain more obvious

### DIFF
--- a/guides/azure/ssl.md
+++ b/guides/azure/ssl.md
@@ -193,9 +193,9 @@ spec:
         pathType: ImplementationSpecific
         backend:
           service:
-            name: juice-balancer
+            name: balancer
             port:
-              number: 3000
+              number: 8080
 ```
 
 Edit the host so that it corresponds to the host associated with your public ip. You find the hostname of your public ip by executing this command.

--- a/guides/azure/ssl.md
+++ b/guides/azure/ssl.md
@@ -101,7 +101,7 @@ NB: See this guide if you have your own domain: https://docs.microsoft.com/en-us
 IP="MY_EXTERNAL_IP"
 
 # Name to associate with public IP address
-DNSNAME="my-multi-juicer"
+DNSNAME="MY_EXTERNAL_DOMAIN"
 
 # Get the resource-id of the public ip
 PUBLICIPID=$(az network public-ip list --query "[?ipAddress!=null]|[?contains(ipAddress, '$IP')].[id]" --output tsv)
@@ -176,26 +176,26 @@ Save the following content as `ingress.yaml`
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: my-multi-juicer
+  name: MY_EXTERNAL_DOMAIN
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
 spec:
   ingressClassName: nginx
   tls:
   - hosts:
-    - my-multi-juicer.<availability zone>.cloudapp.azure.com
+    - MY_EXTERNAL_DOMAIN.<availability zone>.cloudapp.azure.com
     secretName: tls-secret
   rules:
-  - host: my-multi-juicer.<availability zone>.cloudapp.azure.com
+  - host: MY_EXTERNAL_DOMAIN.<availability zone>.cloudapp.azure.com
     http:
       paths:
       - path: /
         pathType: ImplementationSpecific
         backend:
           service:
-            name: balancer
+            name: juice-balancer
             port:
-              number: 8080
+              number: 3000
 ```
 
 Edit the host so that it corresponds to the host associated with your public ip. You find the hostname of your public ip by executing this command.


### PR DESCRIPTION
Just set this up today so two things would make this easier for others to understand:

1. Made MY_EXTERNAL_DOMAIN for unique subdomain in YAML files.
2. Noticed that service for ingress.yaml should be juice-balancer, not just balancer, and needed port 3000, not 8080.

Feel free to reject these edits if they aren't helpful but it took me a bit to figure some of this out so figured this might help others as well.