### PR TITLE
Update chart version to 8.0.4

### DIFF
--- a/helm/multi-juicer/Chart.yaml
+++ b/helm/multi-juicer/Chart.yaml
@@ -28,10 +28,10 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 8.0.1
+version: 8.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 8.0.1
+appVersion: 8.0.4
 
 dependencies: []


### PR DESCRIPTION
Update to match the current tag. Not sure if it would make sense to directly update to 8.0.5?