### PR TITLE
Improve readability of error message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# IntelliJ project files
+*.iml
+.idea/

--- a/balancer/ui/src/cards/InstanceNotFoundCard.tsx
+++ b/balancer/ui/src/cards/InstanceNotFoundCard.tsx
@@ -10,7 +10,7 @@ export const InstanceNotFoundCard = () => {
         alt="Warning"
         className="h-12 w-auto mr-3"
       />
-      <span data-test-id="instance-not-found" className="text-gray-100">
+      <span data-test-id="instance-not-found">
         <FormattedMessage
           id="instance_status_not_found"
           defaultMessage="Could not find the instance for the team. You can recreate it by logging back in."


### PR DESCRIPTION
Before:
<img width="808" alt="Bildschirmfoto 2025-03-04 um 11 33 03" src="https://github.com/user-attachments/assets/09203ae8-0ff3-4e6e-8604-7fc214152620" />

After:
<img width="801" alt="Bildschirmfoto 2025-03-04 um 11 36 18" src="https://github.com/user-attachments/assets/cc934448-e5bc-4a13-a912-87304b721521" />

Dark mode is unchanged:
<img width="819" alt="image" src="https://github.com/user-attachments/assets/ddffefee-28da-461c-a2df-896a8659af4f" />
