### PR TITLE
Backup coding challenge fix 

### DIFF
--- a/progress-watchdog/internal/background-sync.go
+++ b/progress-watchdog/internal/background-sync.go
@@ -1,11 +1,11 @@
 package internal
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"sort"
@@ -16,9 +16,19 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+// Define annotation keys as constants
+const (
+	AnnotationChallenges         = "multi-juicer.owasp-juice.shop/challenges"
+	AnnotationChallengesSolved   = "multi-juicer.owasp-juice.shop/challengesSolved"
+	AnnotationContinueCodeFindIt = "multi-juicer.owasp-juice.shop/continueCodeFindIt"
+	AnnotationContinueCodeFixIt  = "multi-juicer.owasp-juice.shop/continueCodeFixIt"
+)
+
 type ProgressUpdateJobs struct {
-	Team                  string
-	LastChallengeProgress []ChallengeStatus
+	Team                   string
+	LastChallengeProgress  []ChallengeStatus
+	LastContinueCodeFindIt string // Add FindIt code from annotation
+	LastContinueCodeFixIt  string // Add FixIt code from annotation
 }
 
 type ChallengeResponse struct {
@@ -85,24 +95,37 @@ func createProgressUpdateJobs(progressUpdateJobs chan<- ProgressUpdateJobs, clie
 		}
 		juiceShops, err := clientset.AppsV1().Deployments(namespace).List(context.TODO(), opts)
 		if err != nil {
-			panic(err.Error())
+			// Log error instead of panicking
+			logger.Printf("ERROR: Failed to list deployments: %v", err)
+			time.Sleep(30 * time.Second) // Wait before retrying
+			continue
 		}
 
 		logger.Printf("Background-sync started syncing %d instances", len(juiceShops.Items))
 
 		for _, instance := range juiceShops.Items {
-			Team := instance.Labels["team"]
+			team := instance.Labels["team"]
+			annotations := instance.GetAnnotations()
 
 			if instance.Status.ReadyReplicas != 1 {
+				logger.Printf("Skipping sync for team %s, instance not ready", team)
 				continue
 			}
 
 			var lastChallengeProgress []ChallengeStatus
-			json.Unmarshal([]byte(instance.Annotations["multi-juicer.owasp-juice.shop/challenges"]), &lastChallengeProgress)
+			if challengesAnnotation, ok := annotations[AnnotationChallenges]; ok {
+				err := json.Unmarshal([]byte(challengesAnnotation), &lastChallengeProgress)
+				if err != nil {
+					logger.Printf("WARN: Failed to unmarshal challenges annotation for team %s: %v", team, err)
+					// Proceed with empty slice, might trigger restore if instance has progress
+				}
+			}
 
 			progressUpdateJobs <- ProgressUpdateJobs{
-				Team:                  Team,
-				LastChallengeProgress: lastChallengeProgress,
+				Team:                   team,
+				LastChallengeProgress:  lastChallengeProgress,
+				LastContinueCodeFindIt: annotations[AnnotationContinueCodeFindIt], // Read FindIt code
+				LastContinueCodeFixIt:  annotations[AnnotationContinueCodeFixIt],  // Read FixIt code
 			}
 		}
 		time.Sleep(60 * time.Second)
@@ -111,59 +134,129 @@ func createProgressUpdateJobs(progressUpdateJobs chan<- ProgressUpdateJobs, clie
 
 func workOnProgressUpdates(progressUpdateJobs <-chan ProgressUpdateJobs, clientset *kubernetes.Clientset) {
 	for job := range progressUpdateJobs {
+		team := job.Team
 		lastChallengeProgress := job.LastChallengeProgress
-		challengeProgress, err := getCurrentChallengeProgress(job.Team)
+		lastFindItCode := job.LastContinueCodeFindIt
+		lastFixItCode := job.LastContinueCodeFixIt
 
-		if err != nil {
-			logger.Println(fmt.Errorf("failed to fetch current Challenge Progress for team '%s' from Juice Shop: %w", job.Team, err))
+		// Fetch current state from Juice Shop instance
+		currentChallengeProgress, errStandard := getCurrentChallengeProgress(team)
+		currentFindItCode, errFindIt := getCurrentFindItCode(team)
+		currentFixItCode, errFixIt := getCurrentFixItCode(team)
+
+		if errStandard != nil {
+			logger.Println(fmt.Errorf("failed to fetch current Standard Challenge Progress for team '%s': %w", team, errStandard))
+			// Decide how to handle partial failure. Maybe skip this cycle?
 			continue
 		}
+		if errFindIt != nil {
+			logger.Println(fmt.Errorf("failed to fetch current FindIt Code for team '%s': %w", team, errFindIt))
+			// Continue, maybe standard/fixit can still be processed?
+			// Or skip? For now, let's assume fetching might fail temporarily.
+		}
+		if errFixIt != nil {
+			logger.Println(fmt.Errorf("failed to fetch current FixIt Code for team '%s': %w", team, errFixIt))
+			// Continue?
+		}
 
-		switch CompareChallengeStates(challengeProgress, lastChallengeProgress) {
+		// Compare states
+		standardState := CompareChallengeStates(currentChallengeProgress, lastChallengeProgress)
+		findItState := compareCodes(currentFindItCode, lastFindItCode, errFindIt)
+		fixItState := compareCodes(currentFixItCode, lastFixItCode, errFixIt)
+
+		// Determine overall action
+		overallState := NoOp
+		if standardState == ApplyCode || findItState == ApplyCode || fixItState == ApplyCode {
+			overallState = ApplyCode
+		} else if standardState == UpdateCache || findItState == UpdateCache || fixItState == UpdateCache {
+			overallState = UpdateCache
+		}
+
+		switch overallState {
 		case ApplyCode:
-			logger.Printf("Last ContinueCode for team '%s' contains unsolved challenges", job.Team)
-			applyChallengeProgress(job.Team, lastChallengeProgress)
-
-			challengeProgress, err = getCurrentChallengeProgress(job.Team)
-
-			if err != nil {
-				logger.Println(fmt.Errorf("failed to re-fetch challenge progress from Juice Shop for team '%s' to reapply it: %w", job.Team, err))
-				continue
+			logger.Printf("Restoring progress for team '%s'", team)
+			applyChallengeProgress(team, lastChallengeProgress) // Apply stored standard progress
+			if lastFindItCode != "" {
+				applyFindItCode(team, lastFindItCode) // Apply stored FindIt code
 			}
-			PersistProgress(clientset, job.Team, challengeProgress)
+			if lastFixItCode != "" {
+				applyFixItCode(team, lastFixItCode) // Apply stored FixIt code
+			}
+
+			// Refetch after applying to ensure persistence uses the newly set state
+			// Although, ideally Apply should make the instance match the last known state,
+			// re-fetching adds a layer of verification before potentially overwriting annotations.
+			// However, this adds latency and complexity. Let's trust the apply works for now
+			// and persist the state we *intended* to apply.
+			// If issues arise, re-fetch here.
+			PersistProgress(clientset, team, lastChallengeProgress, lastFindItCode, lastFixItCode)
+
 		case UpdateCache:
-			PersistProgress(clientset, job.Team, challengeProgress)
+			// Persist the *currently fetched* state if it differs from the stored state
+			logger.Printf("Updating stored progress for team '%s'", team)
+			PersistProgress(clientset, team, currentChallengeProgress, currentFindItCode, currentFixItCode)
 		case NoOp:
+			// logger.Printf("Progress for team '%s' is in sync", team)
 		}
 	}
+}
+
+// Helper to compare fetched code vs stored code, considering fetch errors
+func compareCodes(currentCode, lastCode string, fetchErr error) UpdateState {
+	if fetchErr != nil {
+		// If we couldn't fetch the current code, we can't determine if cache needs updating.
+		// If there was a *stored* code, it might imply the instance lost progress (ApplyCode),
+		// but we can't be sure without fetching. Safest is NoOp or maybe log a warning.
+		// Let's default to NoOp to avoid unnecessary applies/updates on transient fetch errors.
+		return NoOp
+	}
+
+	if currentCode == lastCode {
+		return NoOp
+	}
+
+	if currentCode != "" && lastCode == "" {
+		// Instance has progress, nothing stored -> UpdateCache
+		return UpdateCache
+	}
+
+	if currentCode == "" && lastCode != "" {
+		// Instance has no progress, but we have it stored -> ApplyCode
+		return ApplyCode
+	}
+
+	if currentCode != lastCode {
+		// Both have codes, but they differ. This implies instance progressed.
+		return UpdateCache
+	}
+
+	return NoOp // Should not be reached
 }
 
 func getCurrentChallengeProgress(team string) ([]ChallengeStatus, error) {
 	url := fmt.Sprintf("http://juiceshop-%s:3000/api/challenges", team)
 
-	req, err := http.NewRequest("GET", url, bytes.NewBuffer([]byte{}))
+	req, err := http.NewRequest("GET", url, nil) // Use nil for GET body
 	if err != nil {
-		panic("Failed to create http request")
+		// Log error instead of panic
+		logger.Printf("ERROR: Failed to create http request for standard challenges for team %s: %v", team, err)
+		return nil, fmt.Errorf("failed to create http request: %w", err)
 	}
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, errors.New("failed to fetch Challenge Status")
+		return nil, fmt.Errorf("failed to fetch standard challenge status: %w", err)
 	}
 	defer res.Body.Close()
 
 	switch res.StatusCode {
-	case 200:
-		defer res.Body.Close()
-
+	case http.StatusOK:
 		challengeResponse := ChallengeResponse{}
-
 		err = json.NewDecoder(res.Body).Decode(&challengeResponse)
 		if err != nil {
 			return nil, errors.New("failed to parse JSON from Juice Shop Challenge Status response")
 		}
 
 		challengeStatus := make(ChallengeStatuses, 0)
-
 		for _, challenge := range challengeResponse.Data {
 			if challenge.Solved {
 				challengeStatus = append(challengeStatus, ChallengeStatus{
@@ -172,35 +265,124 @@ func getCurrentChallengeProgress(team string) ([]ChallengeStatus, error) {
 				})
 			}
 		}
-
 		sort.Stable(challengeStatus)
-
 		return challengeStatus, nil
 	default:
-		return nil, fmt.Errorf("unexpected response status code '%d' from Juice Shop", res.StatusCode)
+		return nil, fmt.Errorf("unexpected response status code '%d' from Juice Shop /api/challenges", res.StatusCode)
 	}
 }
 
+// Fetches the current FindIt continue code from the Juice Shop instance
+func getCurrentFindItCode(team string) (string, error) {
+	return getContinueCode(team, "findIt")
+}
+
+// Fetches the current FixIt continue code from the Juice Shop instance
+func getCurrentFixItCode(team string) (string, error) {
+	return getContinueCode(team, "fixIt")
+}
+
+// Generic function to fetch continue codes (FindIt/FixIt)
+func getContinueCode(team, codeType string) (string, error) {
+	// codeType should be 'findIt' or 'fixIt'
+	url := fmt.Sprintf("http://juiceshop-%s:3000/rest/continue-code-%s", team, codeType)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		logger.Printf("ERROR: Failed to create http request for %s code for team %s: %v", codeType, team, err)
+		return "", fmt.Errorf("failed to create http request for %s code: %w", codeType, err)
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch %s code: %w", codeType, err)
+	}
+	defer res.Body.Close()
+
+	switch res.StatusCode {
+	case http.StatusOK:
+		var response map[string]string
+		err = json.NewDecoder(res.Body).Decode(&response)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse JSON response for %s code: %w", codeType, err)
+		}
+		code, ok := response["continueCode"]
+		if !ok {
+			return "", fmt.Errorf("'continueCode' field not found in %s response", codeType)
+		}
+		return code, nil
+	case http.StatusNotFound: // Handle cases where the endpoint might not exist or no code is generated yet
+		logger.Printf("WARN: No %s code found for team %s (status 404)", codeType, team)
+		return "", nil // Return empty string, not an error
+	default:
+		return "", fmt.Errorf("unexpected status code %d fetching %s code", res.StatusCode, codeType)
+	}
+}
+
+// Applies the stored standard challenge progress to the Juice Shop instance
 func applyChallengeProgress(team string, challengeProgress []ChallengeStatus) {
 	continueCode, err := GenerateContinueCode(challengeProgress)
 	if err != nil {
-		logger.Println(fmt.Errorf("failed to encode challenge progress into continue code: %w", err))
+		logger.Println(fmt.Errorf("failed to generate standard continue code for team %s: %w", team, err))
 		return
+	}
+	if continueCode == "" {
+		logger.Printf("Skipping application of empty standard progress for team %s", team)
+		return // Don't try to apply an empty code
 	}
 
 	url := fmt.Sprintf("http://juiceshop-%s:3000/rest/continue-code/apply/%s", team, continueCode)
-
-	req, err := http.NewRequest("PUT", url, bytes.NewBuffer([]byte{}))
+	err = applyCodeToEndpoint(url, "standard", team)
 	if err != nil {
-		logger.Println(fmt.Errorf("failed to create http request to set the current ContinueCode: %w", err))
+		logger.Println(fmt.Errorf("failed to apply standard progress for team %s: %w", team, err))
+	}
+}
+
+// Applies the stored FindIt continue code to the Juice Shop instance
+func applyFindItCode(team string, code string) {
+	if code == "" {
+		logger.Printf("Skipping application of empty FindIt code for team %s", team)
 		return
+	}
+	url := fmt.Sprintf("http://juiceshop-%s:3000/rest/continue-code-findIt/apply/%s", team, code)
+	err := applyCodeToEndpoint(url, "FindIt", team)
+	if err != nil {
+		logger.Println(fmt.Errorf("failed to apply FindIt code for team %s: %w", team, err))
+	}
+}
+
+// Applies the stored FixIt continue code to the Juice Shop instance
+func applyFixItCode(team string, code string) {
+	if code == "" {
+		logger.Printf("Skipping application of empty FixIt code for team %s", team)
+		return
+	}
+	url := fmt.Sprintf("http://juiceshop-%s:3000/rest/continue-code-fixIt/apply/%s", team, code)
+	err := applyCodeToEndpoint(url, "FixIt", team)
+	if err != nil {
+		logger.Println(fmt.Errorf("failed to apply FixIt code for team %s: %w", team, err))
+	}
+}
+
+// Generic function to apply a continue code via PUT request
+func applyCodeToEndpoint(url string, codeType string, team string) error {
+	req, err := http.NewRequest("PUT", url, nil) // Use nil for PUT body
+	if err != nil {
+		return fmt.Errorf("failed to create http request to apply %s code: %w", codeType, err)
 	}
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
-		logger.Println(fmt.Errorf("failed to set the current ContinueCode to juice shop: %w", err))
-		return
+		return fmt.Errorf("failed to call apply endpoint for %s code: %w", codeType, err)
 	}
 	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusCreated {
+		// Read body for potential error message from Juice Shop
+		bodyBytes, _ := io.ReadAll(res.Body)
+		return fmt.Errorf("unexpected status code %d when applying %s code. Body: %s", res.StatusCode, codeType, string(bodyBytes))
+	}
+	logger.Printf("Successfully applied %s progress/code for team %s", codeType, team)
+	return nil
 }
 
 // ParseContinueCode returns the number of challenges solved by this ContinueCode

--- a/progress-watchdog/internal/background-sync.go
+++ b/progress-watchdog/internal/background-sync.go
@@ -146,17 +146,15 @@ func workOnProgressUpdates(progressUpdateJobs <-chan ProgressUpdateJobs, clients
 
 		if errStandard != nil {
 			logger.Println(fmt.Errorf("failed to fetch current Standard Challenge Progress for team '%s': %w", team, errStandard))
-			// Decide how to handle partial failure. Maybe skip this cycle?
+			// We can skip this cycle too
 			continue
 		}
 		if errFindIt != nil {
 			logger.Println(fmt.Errorf("failed to fetch current FindIt Code for team '%s': %w", team, errFindIt))
-			// Continue, maybe standard/fixit can still be processed?
-			// Or skip? For now, let's assume fetching might fail temporarily.
+			// For now, let's assume fetching might fail temporarily.
 		}
 		if errFixIt != nil {
 			logger.Println(fmt.Errorf("failed to fetch current FixIt Code for team '%s': %w", team, errFixIt))
-			// Continue?
 		}
 
 		// Compare states
@@ -230,7 +228,7 @@ func compareCodes(currentCode, lastCode string, fetchErr error) UpdateState {
 		return UpdateCache
 	}
 
-	return NoOp // Should not be reached
+	return NoOp // Should not be reached (hopefully)
 }
 
 func getCurrentChallengeProgress(team string) ([]ChallengeStatus, error) {

--- a/progress-watchdog/internal/kubernetes.go
+++ b/progress-watchdog/internal/kubernetes.go
@@ -34,35 +34,41 @@ type UpdateProgressDeploymentMetadata struct {
 
 // UpdateProgressDeploymentDiffAnnotations the app specific annotations relevant to the `progress-watchdog`
 type UpdateProgressDeploymentDiffAnnotations struct {
-	Challenges       string `json:"multi-juicer.owasp-juice.shop/challenges"`
-	ChallengesSolved string `json:"multi-juicer.owasp-juice.shop/challengesSolved"`
+	Challenges         string `json:"multi-juicer.owasp-juice.shop/challenges"`
+	ChallengesSolved   string `json:"multi-juicer.owasp-juice.shop/challengesSolved"`
+	ContinueCodeFindIt string `json:"multi-juicer.owasp-juice.shop/continueCodeFindIt,omitempty"`
+	ContinueCodeFixIt  string `json:"multi-juicer.owasp-juice.shop/continueCodeFixIt,omitempty"`
 }
 
-func PersistProgress(clientset *kubernetes.Clientset, team string, solvedChallenges []ChallengeStatus) {
-	logger.Printf("Updating saved ContinueCode of team '%s'", team)
+func PersistProgress(clientset *kubernetes.Clientset, team string, solvedChallenges []ChallengeStatus, continueCodeFindIt string, continueCodeFixIt string) {
+	logger.Printf("Updating saved progress annotations for team '%s'", team)
 
 	encodedSolvedChallenges, err := json.Marshal(solvedChallenges)
 	if err != nil {
-		panic("Could not encode json, to update ContinueCode and challengeSolved count on deployment")
+		logger.Printf("ERROR: Could not encode json for standard challenges for team %s: %v", team, err)
+		return
 	}
 
 	diff := UpdateProgressDeploymentDiff{
 		Metadata: UpdateProgressDeploymentMetadata{
 			Annotations: UpdateProgressDeploymentDiffAnnotations{
-				Challenges:       string(encodedSolvedChallenges),
-				ChallengesSolved: fmt.Sprintf("%d", len(solvedChallenges)),
+				Challenges:         string(encodedSolvedChallenges),
+				ChallengesSolved:   fmt.Sprintf("%d", len(solvedChallenges)),
+				ContinueCodeFindIt: continueCodeFindIt,
+				ContinueCodeFixIt:  continueCodeFixIt,
 			},
 		},
 	}
 
 	jsonBytes, err := json.Marshal(diff)
 	if err != nil {
-		panic("Could not encode json, to update ContinueCode and challengeSolved count on deployment")
+		logger.Printf("ERROR: Could not encode json for deployment patch for team %s: %v", team, err)
+		return
 	}
 
 	namespace := os.Getenv("NAMESPACE")
 	_, err = clientset.AppsV1().Deployments(namespace).Patch(context.TODO(), fmt.Sprintf("juiceshop-%s", team), types.MergePatchType, jsonBytes, v1.PatchOptions{})
 	if err != nil {
-		logger.Println(fmt.Errorf("failed to patch new ContinueCode into deployment for team %s: %w", team, err))
+		logger.Println(fmt.Errorf("failed to patch progress annotations into deployment for team %s: %w", team, err))
 	}
 }

--- a/progress-watchdog/main.go
+++ b/progress-watchdog/main.go
@@ -106,7 +106,7 @@ func main() {
 		challengeStatus = append(challengeStatus, internal.ChallengeStatus{Key: webhook.Solution.Challenge, SolvedAt: webhook.Solution.IssuedOn})
 		sort.Stable(challengeStatus)
 
-		internal.PersistProgress(clientset, team, challengeStatus)
+		internal.PersistProgress(clientset, team, challengeStatus, "", "")
 
 		logger.Printf("Received webhook for team '%s' for challenge '%s'", team, webhook.Solution.Challenge)
 


### PR DESCRIPTION
Fixes issue #95 

@J12934 I did some changes but I low key feel they are not enough. I am getting the findit/fixit codes here now but was that it?

BTW, I also changed some code which panicked to error logs as I heard it was the best practice (also, removed the bytes and replaced it with relevant substitutions (have a look in code changes)

Please suggest if I should change something else or revert stuff

Also, here's a full annotation copy paste. Have a look and see if there's something wrong. 

```

tenxcoder@100xmachine:~/Desktop/GSOC/multi-juicer$ kubectl get deployment juiceshop-testteam -n default -o yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  annotations:
    deployment.kubernetes.io/revision: "1"
    multi-juicer.owasp-juice.shop/challenges: '[{"key":"scoreBoardChallenge","solvedAt":"2025-04-21T19:13:09.813Z"}]'
    multi-juicer.owasp-juice.shop/challengesSolved: "1"
    multi-juicer.owasp-juice.shop/continueCodeFindIt: GDoMmq2QJVNkm9wKRp0WMBaGzD3nAj3VZY5Ee7OqjLPxdvXlyo61gbrdJQO6
    multi-juicer.owasp-juice.shop/continueCodeFixIt: 8bnEDMDmJKYlw6RZ50zLb92nN3gQawG2aGejO4WBpdXPqrM7kvE8yoVkPqjY
    multi-juicer.owasp-juice.shop/lastRequest: "1745262789788"
    multi-juicer.owasp-juice.shop/lastRequestReadable: 2025-04-21 19:13:09.788696042
      +0000 UTC m=+156.736885276
    multi-juicer.owasp-juice.shop/passcode: $2a$10$V1QVexSDqph6COBHhLwCIem5AsOrknvWoOYc/xUgWGw4Akzgm/5o.
  creationTimestamp: "2025-04-21T19:11:22Z"
  generation: 8
  labels:
    app.kubernetes.io/component: vulnerable-app
    app.kubernetes.io/instance: juice-shop-testteam
    app.kubernetes.io/name: juice-shop
    app.kubernetes.io/part-of: multi-juicer
    app.kubernetes.io/version: v17.2.0
    team: testteam
  name: juiceshop-testteam
  namespace: default
  ownerReferences:
  - apiVersion: apps/v1
    blockOwnerDeletion: true
    controller: true
    kind: Deployment
    name: balancer
    uid: bbb8b85a-5000-4a88-a7c9-b36647939f49
  resourceVersion: "864"
  uid: b567494b-1b2d-4ffc-af5c-9e6b34bac221
spec:
  progressDeadlineSeconds: 600
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app.kubernetes.io/name: juice-shop
      app.kubernetes.io/part-of: multi-juicer
      team: testteam
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      creationTimestamp: null
      labels:
        app.kubernetes.io/name: juice-shop
        app.kubernetes.io/part-of: multi-juicer
        app.kubernetes.io/version: v17.2.0
        team: testteam
    spec:
      affinity: {}
      containers:
      - env:
        - name: NODE_ENV
          value: multi-juicer
        - name: CTF_KEY
          value: zLp@.-6fMW6L-7R3b!9uR_K!NfkkTr
        - name: SOLUTIONS_WEBHOOK
          value: http://progress-watchdog.default.svc/team/testteam/webhook
        image: bkimminich/juice-shop:v17.2.0
        imagePullPolicy: IfNotPresent
        livenessProbe:
          failureThreshold: 3
          httpGet:
            path: /rest/admin/application-version
            port: 3000
            scheme: HTTP
          initialDelaySeconds: 30
          periodSeconds: 15
          successThreshold: 1
          timeoutSeconds: 1
        name: juice-shop
        ports:
        - containerPort: 3000
          protocol: TCP
        readinessProbe:
          failureThreshold: 3
          httpGet:
            path: /rest/admin/application-version
            port: 3000
            scheme: HTTP
          periodSeconds: 5
          successThreshold: 1
          timeoutSeconds: 1
        resources:
          requests:
            cpu: 150m
            memory: 300Mi
        securityContext:
          allowPrivilegeEscalation: false
          capabilities:
            drop:
            - ALL
        startupProbe:
          failureThreshold: 150
          httpGet:
            path: /rest/admin/application-version
            port: 3000
            scheme: HTTP
          periodSeconds: 2
          successThreshold: 1
          timeoutSeconds: 1
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        volumeMounts:
        - mountPath: /juice-shop/config/multi-juicer.yaml
          name: juice-shop-config
          readOnly: true
          subPath: multi-juicer.yaml
      dnsPolicy: ClusterFirst
      restartPolicy: Always
      schedulerName: default-scheduler
      securityContext:
        runAsNonRoot: true
      terminationGracePeriodSeconds: 30
      volumes:
      - configMap:
          defaultMode: 420
          name: juice-shop-config
        name: juice-shop-config
status:
  availableReplicas: 1
  conditions:
  - lastTransitionTime: "2025-04-21T19:12:28Z"
    lastUpdateTime: "2025-04-21T19:12:28Z"
    message: Deployment has minimum availability.
    reason: MinimumReplicasAvailable
    status: "True"
    type: Available
  - lastTransitionTime: "2025-04-21T19:11:23Z"
    lastUpdateTime: "2025-04-21T19:12:28Z"
    message: ReplicaSet "juiceshop-testteam-865cc69587" has successfully progressed.
    reason: NewReplicaSetAvailable
    status: "True"
    type: Progressing
  observedGeneration: 8
  readyReplicas: 1
  replicas: 1
  updatedReplicas: 1


```