### PR TITLE
Updating k8s guide load balancer target port to 8080

### DIFF
--- a/guides/k8s/k8s-juice-service.yaml
+++ b/guides/k8s/k8s-juice-service.yaml
@@ -11,4 +11,4 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 3000
+      targetPort: 8080


### PR DESCRIPTION
This tiny PR fix: https://github.com/juice-shop/multi-juicer/issues/332