### PR TITLE
Statistics and fixes 

### DIFF
--- a/balancer/routes/routes.go
+++ b/balancer/routes/routes.go
@@ -37,6 +37,7 @@ func AddRoutes(
 	router.Handle("GET /balancer/api/v2/challenges/{challengeKey}", handleChallengeDetail(bundle, scoringService))
 	router.Handle("GET /balancer/api/teams/status", handleTeamStatus(bundle, scoringService))
 	router.Handle("GET /balancer/api/v2/activity-feed", handleActivityFeed(bundle, scoringService))
+	router.Handle("GET /balancer/api/v2/statistics", handleStatistics(bundle, scoringService))
 
 	router.Handle("GET /balancer/api/admin/all", handleAdminListInstances(bundle))
 	router.Handle("DELETE /balancer/api/admin/teams/{team}/delete", handleAdminDeleteInstance(bundle))

--- a/balancer/routes/routes.go
+++ b/balancer/routes/routes.go
@@ -37,6 +37,7 @@ func AddRoutes(
 	router.Handle("GET /balancer/api/v2/challenges/{challengeKey}", handleChallengeDetail(bundle, scoringService))
 	router.Handle("GET /balancer/api/teams/status", handleTeamStatus(bundle, scoringService))
 	router.Handle("GET /balancer/api/v2/activity-feed", handleActivityFeed(bundle, scoringService))
+	router.Handle("GET /balancer/api/v2/statistics/score-progression", handleScoreProgression(bundle, scoringService))
 	router.Handle("GET /balancer/api/v2/statistics", handleStatistics(bundle, scoringService))
 
 	router.Handle("GET /balancer/api/admin/all", handleAdminListInstances(bundle))

--- a/balancer/routes/scoreProgression.go
+++ b/balancer/routes/scoreProgression.go
@@ -1,0 +1,115 @@
+package routes
+
+import (
+	"encoding/json"
+	"net/http"
+	"sort"
+	"time"
+
+	b "github.com/juice-shop/multi-juicer/balancer/pkg/bundle"
+	"github.com/juice-shop/multi-juicer/balancer/pkg/scoring"
+)
+
+// DataPoint represents a single point in time for a team's score.
+type DataPoint struct {
+	Time  time.Time `json:"time"`
+	Score int       `json:"score"`
+}
+
+// TeamSeries is a series of data points for a single team.
+type TeamSeries struct {
+	Team       string      `json:"team"`
+	DataPoints []DataPoint `json:"datapoints"`
+}
+
+// solveEvent is a temporary struct for processing solves.
+type solveEvent struct {
+	Team   string
+	Points int
+	Time   time.Time
+}
+
+type byTime []solveEvent
+
+func (a byTime) Len() int           { return len(a) }
+func (a byTime) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a byTime) Less(i, j int) bool { return a[i].Time.Before(a[j].Time) }
+
+func handleScoreProgression(bundle *b.Bundle, scoringService *scoring.ScoringService) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		challengeMap := make(map[string]b.JuiceShopChallenge)
+		for _, ch := range bundle.JuiceShopChallenges {
+			challengeMap[ch.Key] = ch
+		}
+
+		// 1. Get the current top 10 teams
+		topTeams := scoringService.GetTopScores()
+		limit := 10
+		if len(topTeams) < limit {
+			limit = len(topTeams)
+		}
+		topTeamSet := make(map[string]bool)
+		for i := 0; i < limit; i++ {
+			topTeamSet[topTeams[i].Name] = true
+		}
+
+		// 2. Collect all solve events ONLY for the top teams
+		allEvents := make([]solveEvent, 0)
+		for _, teamScore := range topTeams[:limit] {
+			for _, solvedChallenge := range teamScore.Challenges {
+				if challengeDetails, ok := challengeMap[solvedChallenge.Key]; ok {
+					allEvents = append(allEvents, solveEvent{
+						Team:   teamScore.Name,
+						Points: challengeDetails.Difficulty * 10,
+						Time:   solvedChallenge.SolvedAt,
+					})
+				}
+			}
+		}
+
+		// 3. Sort all events chronologically
+		sort.Sort(byTime(allEvents))
+
+		// 4. Reconstruct the score history
+		history := make(map[string][]DataPoint)
+		currentScores := make(map[string]int)
+
+		// Determine the start time for the chart. Use a time just before the first event,
+		// or the current time if there are no events.
+		startTime := time.Now()
+		if len(allEvents) > 0 {
+			// Set start time to one second before the very first event
+			startTime = allEvents[0].Time.Add(-1 * time.Second)
+		}
+
+		for teamName := range topTeamSet {
+			// Initialize each team with a starting point at score 0.
+			history[teamName] = []DataPoint{{Time: startTime, Score: 0}}
+			currentScores[teamName] = 0
+		}
+
+		for _, event := range allEvents {
+			// For every other team that is NOT the current event's team,
+			// we add a point to their timeline at the event's timestamp.
+			// This ensures their line stays flat until their next solve.
+			for teamName := range topTeamSet {
+				if teamName != event.Team {
+					history[teamName] = append(history[teamName], DataPoint{Time: event.Time, Score: currentScores[teamName]})
+				}
+			}
+
+			// Update the score for the team that solved the challenge
+			currentScores[event.Team] += event.Points
+			history[event.Team] = append(history[event.Team], DataPoint{Time: event.Time, Score: currentScores[event.Team]})
+		}
+
+		// 5. Format for the response
+		response := make([]TeamSeries, 0, len(history))
+		for team, dataPoints := range history {
+			response = append(response, TeamSeries{Team: team, DataPoints: dataPoints})
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	})
+}

--- a/balancer/routes/scoreProgression_test.go
+++ b/balancer/routes/scoreProgression_test.go
@@ -1,0 +1,71 @@
+package routes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/juice-shop/multi-juicer/balancer/pkg/scoring"
+	"github.com/juice-shop/multi-juicer/balancer/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestScoreProgressionHandler(t *testing.T) {
+	challenge1Key := "scoreBoardChallenge" // 10 pts
+	challenge2Key := "nullByteChallenge"   // 40 pts
+
+	time1 := time.Now().Add(-20 * time.Minute) // team-alpha solves C1
+	time2 := time.Now().Add(-10 * time.Minute) // team-bravo solves C2
+
+	teamAlphaChallenges := fmt.Sprintf(`[{"key":"%s","solvedAt":"%s"}]`, challenge1Key, time1.Format(time.RFC3339))
+	teamBravoChallenges := fmt.Sprintf(`[{"key":"%s","solvedAt":"%s"}]`, challenge2Key, time2.Format(time.RFC3339))
+
+	clientset := fake.NewSimpleClientset(
+		createTeamWithSolvedChallenges("team-alpha", teamAlphaChallenges), // 10 pts
+		createTeamWithSolvedChallenges("team-bravo", teamBravoChallenges), // 40 pts
+	)
+
+	bundle := testutil.NewTestBundleWithCustomFakeClient(clientset)
+	scoringService := scoring.NewScoringService(bundle)
+	scoringService.CalculateAndCacheScoreBoard(context.Background())
+	server := http.NewServeMux()
+	AddRoutes(server, bundle, scoringService)
+
+	req, _ := http.NewRequest("GET", "/balancer/api/v2/statistics/score-progression", nil)
+	rr := httptest.NewRecorder()
+	server.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	var response []TeamSeries
+	err := json.Unmarshal(rr.Body.Bytes(), &response)
+	require.NoError(t, err)
+
+	require.Len(t, response, 2, "Should have a data series for each of the two teams")
+
+	// Create maps for easy lookup
+	seriesMap := make(map[string]TeamSeries)
+	for _, s := range response {
+		seriesMap[s.Team] = s
+	}
+
+	alphaSeries := seriesMap["team-alpha"]
+	bravoSeries := seriesMap["team-bravo"]
+
+	// Verify the data points for team-alpha (score becomes 10 at time1)
+	require.Len(t, alphaSeries.DataPoints, 3)
+	assert.Equal(t, 0, alphaSeries.DataPoints[0].Score)  // Starts at 0
+	assert.Equal(t, 10, alphaSeries.DataPoints[1].Score) // Score becomes 10
+	assert.Equal(t, 10, alphaSeries.DataPoints[2].Score) // Score stays 10 at time2
+
+	// Verify the data points for team-bravo (score becomes 40 at time2)
+	require.Len(t, bravoSeries.DataPoints, 3)
+	assert.Equal(t, 0, bravoSeries.DataPoints[0].Score)  // Starts at 0
+	assert.Equal(t, 0, bravoSeries.DataPoints[1].Score)  // Score is still 0 at time1
+	assert.Equal(t, 40, bravoSeries.DataPoints[2].Score) // Score becomes 40
+}

--- a/balancer/routes/statistics.go
+++ b/balancer/routes/statistics.go
@@ -1,0 +1,81 @@
+package routes
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+
+	b "github.com/juice-shop/multi-juicer/balancer/pkg/bundle"
+	"github.com/juice-shop/multi-juicer/balancer/pkg/scoring"
+)
+
+type CategoryStat struct {
+	Category string `json:"category"`
+	Solves   int    `json:"solves"`
+}
+
+type ScoreBucket struct {
+	Range string `json:"range"`
+	Count int    `json:"count"`
+}
+
+type StatisticsResponse struct {
+	CategoryStats     []CategoryStat `json:"categoryStats"`
+	ScoreDistribution []ScoreBucket  `json:"scoreDistribution"`
+}
+
+func handleStatistics(bundle *b.Bundle, scoringService *scoring.ScoringService) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		allTeamScores := scoringService.GetScores()
+		challengeMap := make(map[string]b.JuiceShopChallenge)
+		for _, ch := range bundle.JuiceShopChallenges {
+			challengeMap[ch.Key] = ch
+		}
+
+		// 1. Calculate Category Statistics
+		categoryCounts := make(map[string]int)
+		for _, teamScore := range allTeamScores {
+			for _, solvedChallenge := range teamScore.Challenges {
+				if details, ok := challengeMap[solvedChallenge.Key]; ok {
+					categoryCounts[details.Category]++
+				}
+			}
+		}
+		categoryStats := make([]CategoryStat, 0, len(categoryCounts))
+		for category, count := range categoryCounts {
+			categoryStats = append(categoryStats, CategoryStat{Category: category, Solves: count})
+		}
+		// Sort for consistent ordering
+		sort.Slice(categoryStats, func(i, j int) bool {
+			return categoryStats[i].Solves > categoryStats[j].Solves
+		})
+
+		// 2. Calculate Score Distribution
+		// Buckets of 100 points, up to 1000, then 1000+
+		scoreBuckets := make([]ScoreBucket, 11)
+		for i := 0; i < 10; i++ {
+			scoreBuckets[i] = ScoreBucket{Range: fmt.Sprintf("%d-%d", i*100, (i+1)*100-1)}
+		}
+		scoreBuckets[10] = ScoreBucket{Range: "1000+"}
+
+		for _, teamScore := range allTeamScores {
+			bucketIndex := teamScore.Score / 100
+			if bucketIndex >= 10 {
+				bucketIndex = 10 // Put everything >= 1000 in the last bucket
+			}
+			if bucketIndex >= 0 {
+				scoreBuckets[bucketIndex].Count++
+			}
+		}
+
+		// 3. Construct and send the response
+		response := StatisticsResponse{
+			CategoryStats:     categoryStats,
+			ScoreDistribution: scoreBuckets,
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	})
+}

--- a/balancer/routes/statistics_test.go
+++ b/balancer/routes/statistics_test.go
@@ -1,0 +1,108 @@
+package routes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/juice-shop/multi-juicer/balancer/pkg/scoring"
+	"github.com/juice-shop/multi-juicer/balancer/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestStatisticsHandler(t *testing.T) {
+	createTeamWithSolvedChallenges := func(team string, challengesJSON string) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("juiceshop-%s", team),
+				Namespace: "test-namespace",
+				Annotations: map[string]string{
+					"multi-juicer.owasp-juice.shop/challenges": challengesJSON,
+				},
+				Labels: map[string]string{"app.kubernetes.io/name": "juice-shop", "app.kubernetes.io/part-of": "multi-juicer", "team": team},
+			},
+			Status: appsv1.DeploymentStatus{ReadyReplicas: 1},
+		}
+	}
+
+	// --- Test Data Setup ---
+	// Challenge difficulties: scoreBoardChallenge=1 (10pts), nullByteChallenge=4 (40pts)
+	challenge1Key := "scoreBoardChallenge"
+	challenge2Key := "nullByteChallenge"
+
+	// team-alpha: score 10
+	teamAlphaChallenges := fmt.Sprintf(`[{"key":"%s","solvedAt":"%s"}]`, challenge1Key, time.Now().Format(time.RFC3339))
+	// team-bravo: score 50 (10 + 40)
+	teamBravoChallenges := fmt.Sprintf(`[{"key":"%s","solvedAt":"%s"},{"key":"%s","solvedAt":"%s"}]`,
+		challenge1Key, time.Now().Format(time.RFC3339), challenge2Key, time.Now().Format(time.RFC3339))
+	// team-charlie: score 40
+	teamCharlieChallenges := fmt.Sprintf(`[{"key":"%s","solvedAt":"%s"}]`, challenge2Key, time.Now().Format(time.RFC3339))
+
+	clientset := fake.NewSimpleClientset(
+		createTeamWithSolvedChallenges("team-alpha", teamAlphaChallenges),
+		createTeamWithSolvedChallenges("team-bravo", teamBravoChallenges),
+		createTeamWithSolvedChallenges("team-charlie", teamCharlieChallenges),
+	)
+
+	bundle := testutil.NewTestBundleWithCustomFakeClient(clientset)
+	// Add categories to the test challenges for category stats
+	for i, ch := range bundle.JuiceShopChallenges {
+		if ch.Key == challenge1Key {
+			bundle.JuiceShopChallenges[i].Category = "Category A"
+		}
+		if ch.Key == challenge2Key {
+			bundle.JuiceShopChallenges[i].Category = "Category B"
+		}
+	}
+
+	scoringService := scoring.NewScoringService(bundle)
+	err := scoringService.CalculateAndCacheScoreBoard(context.Background())
+	require.NoError(t, err)
+
+	server := http.NewServeMux()
+	AddRoutes(server, bundle, scoringService)
+
+	// --- Test Execution ---
+	req, _ := http.NewRequest("GET", "/balancer/api/v2/statistics", nil)
+	rr := httptest.NewRecorder()
+	server.ServeHTTP(rr, req)
+
+	// --- Assertions ---
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var stats StatisticsResponse
+	err = json.Unmarshal(rr.Body.Bytes(), &stats)
+	require.NoError(t, err)
+
+	// 1. Verify Category Stats
+	require.Len(t, stats.CategoryStats, 2, "Should be two categories with solves")
+	// Note: The order is not guaranteed, so we check for existence
+	expectedCatA := CategoryStat{Category: "Category A", Solves: 2} // solved by alpha and bravo
+	expectedCatB := CategoryStat{Category: "Category B", Solves: 2} // solved by bravo and charlie
+	assert.Contains(t, stats.CategoryStats, expectedCatA)
+	assert.Contains(t, stats.CategoryStats, expectedCatB)
+
+	// 2. Verify Score Distribution
+	// Scores are 10, 50, 40. Bucket size is 100.
+	// Bucket "0-99" should contain all 3 teams.
+	// All other buckets should contain 0.
+	require.Len(t, stats.ScoreDistribution, 11, "The API should always return 11 score buckets")
+
+	// Create a map for easy lookup
+	bucketMap := make(map[string]int)
+	for _, bucket := range stats.ScoreDistribution {
+		bucketMap[bucket.Range] = bucket.Count
+	}
+
+	assert.Equal(t, 3, bucketMap["0-99"], "Bucket '0-99' should have 3 teams")
+	assert.Equal(t, 0, bucketMap["100-199"], "Bucket '100-199' should be empty")
+	assert.Equal(t, 0, bucketMap["200-299"], "Bucket '200-299' should be empty")
+}

--- a/balancer/ui/package-lock.json
+++ b/balancer/ui/package-lock.json
@@ -18,6 +18,7 @@
         "react-intl": "^7.1.11",
         "react-router-dom": "^7.6.3",
         "reactjs-popup": "^2.0.6",
+        "recharts": "^3.1.0",
         "tailwindcss": "^4.0.14"
       },
       "devDependencies": {
@@ -1053,6 +1054,32 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.8.2.tgz",
+      "integrity": "sha512-MYlOhQ0sLdw4ud48FoC5w0dH9VfWQjtCjreKwYTT3l+r427qYC5Y8PihNutepr8XrNaBUDQo9khWUwQxZaqt5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.19",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.19.tgz",
@@ -1339,6 +1366,18 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.11",
@@ -1890,6 +1929,69 @@
         "@types/deep-eql": "*"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1958,6 +2060,12 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.5.tgz",
       "integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
@@ -2257,6 +2365,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2319,6 +2436,127 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -2355,6 +2593,12 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
       "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/deep-eql": {
@@ -2438,6 +2682,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/es-toolkit": {
+      "version": "1.39.7",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.7.tgz",
+      "integrity": "sha512-ek/wWryKouBrZIjkwW2BFf91CWOIMvoy2AE5YYgUrfWsJQM2Su1LoLtrw8uusEpN9RfqLlV/0FVNjT0WMv8Bxw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.0.tgz",
@@ -2498,6 +2752,12 @@
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.2.1",
@@ -2660,6 +2920,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -2668,6 +2938,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/intl-messageformat": {
@@ -3363,6 +3642,29 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -3421,6 +3723,33 @@
         "react-dom": ">=16"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.1.0.tgz",
+      "integrity": "sha512-NqAqQcGBmLrfDs2mHX/bz8jJCQtG2FeXfE0GqpZmIuXIjkpIwj8sd9ad0WyvKiBKPd8ZgNG0hL85c8sFDwascw==",
+      "license": "MIT",
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -3435,11 +3764,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
     "node_modules/retry": {
@@ -3696,6 +4046,12 @@
       "optional": true,
       "peer": true
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -3860,6 +4216,37 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {
@@ -4732,6 +5119,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "@reduxjs/toolkit": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.8.2.tgz",
+      "integrity": "sha512-MYlOhQ0sLdw4ud48FoC5w0dH9VfWQjtCjreKwYTT3l+r427qYC5Y8PihNutepr8XrNaBUDQo9khWUwQxZaqt5A==",
+      "requires": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      }
+    },
     "@rolldown/pluginutils": {
       "version": "1.0.0-beta.19",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.19.tgz",
@@ -4877,6 +5277,16 @@
       "integrity": "sha512-lpPE1cLfP5oPzVjKMx10pgBmKELQnFJXHgvtHCtuJWOv8MxqdEIMNtgHgBFf7Ea2/7EuVwa9fodWUfXAlXZLZQ==",
       "dev": true,
       "optional": true
+    },
+    "@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="
+    },
+    "@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="
     },
     "@tailwindcss/node": {
       "version": "4.1.11",
@@ -5235,6 +5645,60 @@
         "@types/deep-eql": "*"
       }
     },
+    "@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg=="
+    },
+    "@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+    },
+    "@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
+    },
+    "@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "requires": {
+        "@types/d3-color": "*"
+      }
+    },
+    "@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="
+    },
+    "@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "requires": {
+        "@types/d3-time": "*"
+      }
+    },
+    "@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "requires": {
+        "@types/d3-path": "*"
+      }
+    },
+    "@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="
+    },
+    "@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
+    },
     "@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -5296,6 +5760,11 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.5.tgz",
       "integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==",
       "dev": true
+    },
+    "@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="
     },
     "@vitejs/plugin-react": {
       "version": "4.6.0",
@@ -5478,6 +5947,11 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
       "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="
     },
+    "clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
+    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -5525,6 +5999,83 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
+    "d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "requires": {
+        "internmap": "1 - 2"
+      }
+    },
+    "d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
+    },
+    "d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="
+    },
+    "d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA=="
+    },
+    "d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "requires": {
+        "d3-color": "1 - 3"
+      }
+    },
+    "d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="
+    },
+    "d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "requires": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      }
+    },
+    "d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "requires": {
+        "d3-path": "^3.1.0"
+      }
+    },
+    "d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "requires": {
+        "d3-array": "2 - 3"
+      }
+    },
+    "d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "requires": {
+        "d3-time": "1 - 3"
+      }
+    },
+    "d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="
+    },
     "data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -5548,6 +6099,11 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
       "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw=="
+    },
+    "decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
     "deep-eql": {
       "version": "5.0.2",
@@ -5605,6 +6161,11 @@
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true
     },
+    "es-toolkit": {
+      "version": "1.39.7",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.7.tgz",
+      "integrity": "sha512-ek/wWryKouBrZIjkwW2BFf91CWOIMvoy2AE5YYgUrfWsJQM2Su1LoLtrw8uusEpN9RfqLlV/0FVNjT0WMv8Bxw=="
+    },
     "esbuild": {
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.0.tgz",
@@ -5652,6 +6213,11 @@
       "requires": {
         "@types/estree": "^1.0.0"
       }
+    },
+    "eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "expect-type": {
       "version": "1.2.1",
@@ -5752,11 +6318,21 @@
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
     },
+    "immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw=="
+    },
     "indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true
+    },
+    "internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="
     },
     "intl-messageformat": {
       "version": "10.7.16",
@@ -6133,6 +6709,15 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "requires": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      }
+    },
     "react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -6162,6 +6747,24 @@
       "integrity": "sha512-A+tt+x9wdgZiZjv0e2WzYLD3IfFwJALaRaqwrCSXGjo0iQdsry/EtBEbQXRSmQs7cHmOi5eytCiSlOm8k4C+dg==",
       "requires": {}
     },
+    "recharts": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.1.0.tgz",
+      "integrity": "sha512-NqAqQcGBmLrfDs2mHX/bz8jJCQtG2FeXfE0GqpZmIuXIjkpIwj8sd9ad0WyvKiBKPd8ZgNG0hL85c8sFDwascw==",
+      "requires": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      }
+    },
     "redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -6172,11 +6775,27 @@
         "strip-indent": "^3.0.0"
       }
     },
+    "redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
+    },
+    "redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "requires": {}
+    },
     "regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
       "dev": true
+    },
+    "reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="
     },
     "retry": {
       "version": "0.12.0",
@@ -6381,6 +7000,11 @@
         }
       }
     },
+    "tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+    },
     "tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -6481,6 +7105,33 @@
       "requires": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.1"
+      }
+    },
+    "use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "requires": {}
+    },
+    "victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "requires": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "vite": {

--- a/balancer/ui/package.json
+++ b/balancer/ui/package.json
@@ -13,6 +13,7 @@
     "react-intl": "^7.1.11",
     "react-router-dom": "^7.6.3",
     "reactjs-popup": "^2.0.6",
+    "recharts": "^3.1.0",
     "tailwindcss": "^4.0.14"
   },
   "devDependencies": {

--- a/balancer/ui/src/App.tsx
+++ b/balancer/ui/src/App.tsx
@@ -8,6 +8,7 @@ import { JoiningPage } from "./pages/JoiningPage";
 import { TeamStatusPage } from "./pages/TeamStatusPage";
 
 import { Layout } from "./Layout";
+import { LayoutV2 } from "./LayoutV2"; 
 import { Spinner } from "./components/Spinner";
 import { MessageLoader } from "./translations/index";
 import { Toaster } from "react-hot-toast";
@@ -18,7 +19,7 @@ const IndividualScorePage = lazy(() => import("./pages/IndividualScorePage"));
 const ScoreboardV2Page = lazy(() => import("./pages/v2/ScoreboardV2Page"));
 const TeamDetailPageV2 = lazy(() => import("./pages/v2/TeamDetailPageV2"));
 const ChallengeDetailPageV2 = lazy(() => import("./pages/v2/ChallengeDetailPageV2"));
-
+const StatisticsPageV2 = lazy(() => import("./pages/v2/StatisticsPageV2")); 
 
 interface SimplifiedTeamStatusResponse {
   name: string;
@@ -75,8 +76,26 @@ function App() {
     <IntlProvider defaultLocale="en" locale={locale} messages={messages}>
       <BrowserRouter basename="/balancer">
         <Routes>
+          {/* --- V2 Routes with the new LayoutV2 --- */}
           <Route
-            path="*"
+            path="/v2/*" // Match all routes starting with /v2
+            element={
+              <LayoutV2>
+                <Suspense fallback={<Spinner />}>
+                  <Routes>
+                    <Route path="/" element={<ScoreboardV2Page />} />
+                    <Route path="/statistics" element={<StatisticsPageV2 />} />
+                    <Route path="/teams/:team" element={<TeamDetailPageV2 />} />
+                    <Route path="/challenges/:challengeKey" element={<ChallengeDetailPageV2 />} />
+                  </Routes>
+                </Suspense>
+              </LayoutV2>
+            }
+          />
+
+          {/* --- V1 (Old) Routes with the old Layout --- */}
+          <Route
+            path="/*"
             element={
               <Layout
                 activeTeam={activeTeam}
@@ -111,23 +130,11 @@ function App() {
                       path="/score-overview/teams/:team"
                       element={<IndividualScorePage />}
                     />
-                    <Route 
-                      path="/v2" 
-                      element={<ScoreboardV2Page />} 
-                    />
-                    <Route 
-                      path="/v2/teams/:team" 
-                      element={<TeamDetailPageV2 />} 
-                    />
-                    <Route 
-                      path="/v2/challenges/:challengeKey"
-                      element={<ChallengeDetailPageV2 />} 
-                    />
                   </Routes>
                 </Suspense>
               </Layout>
             }
-          ></Route>
+          />
         </Routes>
       </BrowserRouter>
       <Toaster />

--- a/balancer/ui/src/LayoutV2.tsx
+++ b/balancer/ui/src/LayoutV2.tsx
@@ -1,0 +1,48 @@
+import { ReactNode } from 'react';
+import { NavLink, Link } from 'react-router-dom';
+import { Card } from './components/Card';
+import { classNames } from './util/classNames';
+
+const navLinkClasses = "px-4 py-2 rounded-md text-sm font-medium transition-colors";
+const activeNavLinkClasses = "bg-orange-500 text-white";
+const inactiveNavLinkClasses = "text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700";
+
+export const LayoutV2 = ({ children }: { children: ReactNode }) => {
+  return (
+    <div className="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 flex flex-col gap-6">
+      <header>
+        <Card className="p-4 flex justify-between items-center">
+          {/* Logo */}
+          <Link to="/v2" className="flex items-center gap-3">
+            <img
+              src="/balancer/multi-juicer.svg"
+              alt="MultiJuicer Logo"
+              className="h-10" // Smaller logo
+            />
+          </Link>
+
+          {/* Navigation Toggle */}
+          <div className="flex items-center p-1 bg-gray-100 dark:bg-gray-800 rounded-lg">
+            <NavLink
+              to="/v2"
+              end // 'end' prop ensures this only matches the exact path
+              className={({ isActive }) => classNames(navLinkClasses, isActive ? activeNavLinkClasses : inactiveNavLinkClasses)}
+            >
+              Leaderboard
+            </NavLink>
+            <NavLink
+              to="/v2/statistics"
+              className={({ isActive }) => classNames(navLinkClasses, isActive ? activeNavLinkClasses : inactiveNavLinkClasses)}
+            >
+              Statistics
+            </NavLink>
+          </div>
+        </Card>
+      </header>
+
+      <main className="flex flex-col items-center justify-center">
+        {children}
+      </main>
+    </div>
+  );
+};

--- a/balancer/ui/src/pages/v2/ScoreboardV2Page.tsx
+++ b/balancer/ui/src/pages/v2/ScoreboardV2Page.tsx
@@ -132,10 +132,6 @@ export const ScoreboardV2Page = () => {
   <div className="w-full max-w-7xl grid grid-cols-1 lg:grid-cols-3 gap-8">
     {/* Main scoreboard content */}
     <div className="lg:col-span-2">
-      <h1 className="text-3xl font-bold text-center mb-6">
-        <FormattedMessage id="v2.scoreboard.title" defaultMessage="Scoreboard" />
-      </h1>
-
       <LayoutGroup>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
           <AnimatePresence>

--- a/balancer/ui/src/pages/v2/StatisticsPageV2.tsx
+++ b/balancer/ui/src/pages/v2/StatisticsPageV2.tsx
@@ -1,0 +1,10 @@
+export const StatisticsPageV2 = () => {
+  return (
+    <div className="text-center">
+      <h1 className="text-2xl font-bold">Statistics</h1>
+      <p className="text-gray-500 mt-2">This page is under construction.</p>
+    </div>
+  );
+};
+
+export default StatisticsPageV2

--- a/balancer/ui/src/pages/v2/StatisticsPageV2.tsx
+++ b/balancer/ui/src/pages/v2/StatisticsPageV2.tsx
@@ -1,10 +1,134 @@
+import { useState, useEffect } from "react";
+import { Card } from "../../components/Card";
+import { Spinner } from "../../components/Spinner";
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid } from 'recharts';
+import { FormattedMessage } from "react-intl";
+
+// --- Type Definitions ---
+interface CategoryStat {
+  category: string;
+  solves: number;
+}
+interface ScoreBucket {
+  range: string;
+  count: number;
+}
+interface StatisticsData {
+  categoryStats: CategoryStat[];
+  scoreDistribution: ScoreBucket[];
+}
+
+// --- API Fetching ---
+async function fetchStatistics(): Promise<StatisticsData> {
+  const response = await fetch("/balancer/api/v2/statistics");
+  if (!response.ok) {
+    throw new Error("Failed to fetch statistics");
+  }
+  return response.json();
+}
+
+// --- Chart Components ---
+const COLORS = ['#FF8042', '#0088FE', '#00C49F', '#FFBB28', '#FF4444', '#A463F2'];
+
+const CategoryPieChart = ({ data }: { data: CategoryStat[] }) => (
+  <Card className="p-4 border-t-4 border-orange-500">
+    <h3 className="font-bold mb-4">
+      <FormattedMessage id="v2.stats.category_solves" defaultMessage="Challenge Solves by Category" />
+    </h3>
+    <div style={{ width: '100%', height: 300 }}>
+      <ResponsiveContainer>
+        <PieChart>
+          <Pie data={data} dataKey="solves" nameKey="category" cx="50%" cy="50%" outerRadius={100} fill="#8884d8" label>
+            {data.map((index) => (
+              <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+            ))}
+          </Pie>
+          <Tooltip />
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  </Card>
+);
+
+const ScoreDistributionChart = ({ data }: { data: ScoreBucket[] }) => (
+  <Card className="p-4 border-t-4 border-orange-500">
+    <h3 className="font-bold mb-4">
+      <FormattedMessage id="v2.stats.score_distribution" defaultMessage="Score Distribution" />
+    </h3>
+    <div style={{ width: '100%', height: 300 }}>
+      <ResponsiveContainer>
+        <BarChart data={data} layout="vertical" margin={{ top: 5, right: 20, left: 20, bottom: 5 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis type="number" />
+          <YAxis type="category" dataKey="range" width={80} />
+          <Tooltip />
+          <Bar dataKey="count" fill="#FF8042" barSize={20} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  </Card>
+);
+
+const PlaceholderChart = () => (
+    <Card className="p-4 border-t-4 border-gray-400">
+        <h3 className="font-bold mb-4 text-gray-500">
+            <FormattedMessage id="v2.stats.score_progression" defaultMessage="Score Progression" />
+        </h3>
+        <div className="h-[300px] flex items-center justify-center text-gray-400">
+            <FormattedMessage id="v2.stats.coming_soon" defaultMessage="Chart coming soon! (Requires backend changes for historical data)" />
+        </div>
+    </Card>
+);
+
+
+// --- Main Page Component ---
 export const StatisticsPageV2 = () => {
+  const [stats, setStats] = useState<StatisticsData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        const data = await fetchStatistics();
+        setStats(data);
+      } catch (error) {
+        console.error(error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    loadData();
+  }, []);
+
+  if (isLoading) {
+    return <Spinner />;
+  }
+
+  if (!stats) {
+    return <p>Could not load statistics.</p>;
+  }
+
+  const hasData = stats.categoryStats.length > 0;
+
   return (
-    <div className="text-center">
-      <h1 className="text-2xl font-bold">Statistics</h1>
-      <p className="text-gray-500 mt-2">This page is under construction.</p>
+    <div className="w-full">
+      <div className="mb-6">
+        <PlaceholderChart />
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {hasData ? (
+          <>
+            <CategoryPieChart data={stats.categoryStats} />
+            <ScoreDistributionChart data={stats.scoreDistribution} />
+          </>
+        ) : (
+          <div className="md:col-span-2 text-center p-8 text-gray-500">
+            <FormattedMessage id="v2.stats.no_data" defaultMessage="Awaiting first solve to generate statistics..." />
+          </div>
+        )}
+      </div>
     </div>
   );
 };
 
-export default StatisticsPageV2
+export default StatisticsPageV2;

--- a/balancer/ui/src/pages/v2/StatisticsPageV2.tsx
+++ b/balancer/ui/src/pages/v2/StatisticsPageV2.tsx
@@ -39,7 +39,7 @@ const CategoryPieChart = ({ data }: { data: CategoryStat[] }) => (
       <ResponsiveContainer>
         <PieChart>
           <Pie data={data} dataKey="solves" nameKey="category" cx="50%" cy="50%" outerRadius={100} fill="#8884d8" label>
-            {data.map((index) => (
+            {data.map((_, index) => (
               <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
             ))}
           </Pie>


### PR DESCRIPTION
Description:
Introduces the new V2 Statistics page a

What's New:

- New Statistics Page (/v2/statistics)

Added a fully functional statistics page with two interactive charts powered by recharts:
A Pie Chart visualizing the number of solves per challenge category.
A Bar Chart showing the distribution of team scores across different point ranges.
Includes a placeholder for a future "Score Progression" chart, acknowledging the need for further backend work.
New Backend Statistics API (/balancer/api/v2/statistics)

Created a new backend endpoint to calculate and provide the aggregated data needed for the charts.
This endpoint is covered by a comprehensive new unit test (statistics_test.go) that verifies its calculations for both category solves and score distribution.
How to Test:
Run the project: task dev
Navigate to the V2 Scoreboard: Go to http://localhost:8080/balancer/v2.
Verify: You should see the new header provided by LayoutV2.
Test Navigation: Click the "Statistics" button in the new header.
Verify: The URL should change to /v2/statistics, and the new statistics page with charts should appear, rendered within the same LayoutV2 header.
Verify Data: Create a few teams and solve some challenges to see the charts populate with data.