### PR TITLE
Fix: Use Chart.AppVersion instead of Chart.Version for all image tags to achieve Flux/OCI compatibility

### DIFF
--- a/helm/multi-juicer/templates/balancer/deployment.yaml
+++ b/helm/multi-juicer/templates/balancer/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: '{{ .Values.balancer.repository }}:{{ .Values.balancer.tag | default (printf "v%s" .Chart.Version) }}'
+          image: '{{ .Values.balancer.repository }}:{{ .Values.balancer.tag | default (printf "v%s" .Chart.AppVersion) }}'
           imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
           {{- with .Values.balancer.containerSecurityContext }}
           securityContext:

--- a/helm/multi-juicer/templates/cleanup/cron-job.yaml
+++ b/helm/multi-juicer/templates/cleanup/cron-job.yaml
@@ -26,7 +26,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           containers:
-            - image: '{{ .Values.juiceShopCleanup.repository }}:{{ .Values.juiceShopCleanup.tag | default (printf "v%s" .Chart.Version) }}'
+            - image: '{{ .Values.juiceShopCleanup.repository }}:{{ .Values.juiceShopCleanup.tag | default (printf "v%s" .Chart.AppVersion) }}'
               imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
               name: 'cleanup-job'
               {{- with .Values.juiceShopCleanup.containerSecurityContext }}

--- a/helm/multi-juicer/templates/progress-watchdog/deployment.yaml
+++ b/helm/multi-juicer/templates/progress-watchdog/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       {{- end }}
       containers:
         - name: progress-watchdog
-          image: '{{ .Values.progressWatchdog.repository }}:{{ .Values.progressWatchdog.tag | default (printf "v%s" .Chart.Version) }}'
+          image: '{{ .Values.progressWatchdog.repository }}:{{ .Values.progressWatchdog.tag | default (printf "v%s" .Chart.AppVersion) }}'
           imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
           {{- with .Values.progressWatchdog.containerSecurityContext }}
           securityContext:

--- a/helm/multi-juicer/tests/flux-oci_test.yaml
+++ b/helm/multi-juicer/tests/flux-oci_test.yaml
@@ -1,0 +1,61 @@
+suite: OCI & Flux Version Compliance
+# DOCUMENTATION:
+# These tests ensure that Chart.AppVersion is used for image tags instead of
+# Chart.Version. Flux/GitOps tools inject SemVer build metadata (e.g. "+38f0858")
+# into Chart.Version but NOT into Chart.AppVersion, making AppVersion safe for
+# Docker tags (which cannot contain "+").
+
+tests:
+  # ==========================================================
+  # TEST 1: Progress Watchdog Component
+  # ==========================================================
+  - it: progress-watchdog should use Chart.AppVersion for image tag even when Chart.Version has build metadata
+    templates:
+      - templates/progress-watchdog/deployment.yaml
+    
+    # Simulate Flux behavior: Chart.Version has build metadata, but AppVersion doesn't
+    chart:
+      version: "8.3.0+38f085896f69"
+      appVersion: "8.3.0"
+
+    # The image tag should use AppVersion (clean), not Chart.Version (with +metadata)
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "ghcr.io/juice-shop/multi-juicer/progress-watchdog:v8.3.0"
+
+  # ==========================================================
+  # TEST 2: Balancer Component
+  # ==========================================================
+  - it: balancer should use Chart.AppVersion for image tag even when Chart.Version has build metadata
+    templates:
+      - templates/balancer/deployment.yaml
+    
+    # Simulate Flux behavior: Chart.Version has build metadata, but AppVersion doesn't
+    chart:
+      version: "8.3.0+38f085896f69"
+      appVersion: "8.3.0"
+    
+    # The image tag should use AppVersion (clean), not Chart.Version (with +metadata)
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "ghcr.io/juice-shop/multi-juicer/balancer:v8.3.0"
+
+  # ==========================================================
+  # TEST 3: Cleanup CronJob Component
+  # ==========================================================
+  - it: cleanup cronjob should use Chart.AppVersion for image tag even when Chart.Version has build metadata
+    templates:
+      - templates/cleanup/cron-job.yaml
+    
+    # Simulate Flux behavior: Chart.Version has build metadata, but AppVersion doesn't
+    chart:
+      version: "8.3.0+38f085896f69"
+      appVersion: "8.3.0"
+    
+    # The image tag should use AppVersion (clean), not Chart.Version (with +metadata)
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].image
+          value: "ghcr.io/juice-shop/multi-juicer/cleaner:v8.3.0"


### PR DESCRIPTION
## Problem
When deploying multi-juicer using [Flux OCIRepository](https://fluxcd.io/flux/components/source/ocirepositories/), Chart versions include build metadata (e.g., `8.3.0+38f085896f69`). This metadata, which contains the `+` character, creates invalid Docker image tags, causing deployment failures.

The `+` character is valid in SemVer but not allowed in Docker tags, breaking pod creation when Flux injects this metadata into the Chart.Version.

## Solution
- Use Chart.AppVersion instead of Chart.Version for all image tags as default.
- Applied the change to all components:
  - balancer deployment
  - progress-watchdog deployment  
  - cleanup cronjob
- Added unit tests to verify Flux/OCI compliance

## Testing
All helm unit tests pass:
```bash
helm unittest .