### PR TITLE
fix: use strict comparator for sort to follow Go contract

### DIFF
--- a/progress-watchdog/internal/kubernetes.go
+++ b/progress-watchdog/internal/kubernetes.go
@@ -25,7 +25,7 @@ type ChallengeStatus struct {
 type ChallengeStatuses []ChallengeStatus
 
 func (a ChallengeStatuses) Len() int           { return len(a) }
-func (a ChallengeStatuses) Less(i, j int) bool { return strings.Compare(a[i].Key, a[j].Key) >= 0 }
+func (a ChallengeStatuses) Less(i, j int) bool { return strings.Compare(a[i].Key, a[j].Key) > 0 }
 func (a ChallengeStatuses) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 
 type UpdateProgressDeploymentDiff struct {


### PR DESCRIPTION
### Description
Fixes the sort comparator in progress-watchdog to use a strict ordering.

Replaced:
    strings.Compare(a, b) >= 0
with:
    strings.Compare(a, b) > 0

This ensures compliance with Go’s sort.Interface contract. While duplicate values are not expected in the current logic, this change follows best practices and prevents potential issues if assumptions change in the future.

Fixes issue #481 

### AI Tool Disclosure

- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`
