### PR TITLE
Add custom balancer logo option

### DIFF
--- a/helm/multi-juicer/README.md
+++ b/helm/multi-juicer/README.md
@@ -19,6 +19,7 @@ MultiJuicer gives you the ability to run separate Juice Shop instances for every
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Optional Configure kubernetes scheduling affinity for the created JuiceShops (see: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
+| balancer.logoUrl | string | `""` | Optional URL to a custom logo for the MultiJuicer balancer UI. If this points to an external host, update `contentSecurityPolicy` to allow that image source. |
 | config.juiceShop.affinity | object | `{}` | Optional Configure kubernetes scheduling affinity for the created JuiceShops (see: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) |
 | config.juiceShop.config | object | See values.yaml for full details | Specify a custom Juice Shop config.yaml. See the JuiceShop Config Docs for more detail: https://pwning.owasp-juice.shop/companion-guide/latest/part4/customization.html#_yaml_configuration_file |
 | config.juiceShop.containerSecurityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}` | Optional securityContext on container level: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core |

--- a/helm/multi-juicer/templates/deployment.yaml
+++ b/helm/multi-juicer/templates/deployment.yaml
@@ -60,6 +60,10 @@ spec:
                 name: multi-juicer-secret
           - name: MULTI_JUICER_CONTENT_SECURITY_POLICY
             value: {{ .Values.contentSecurityPolicy | quote }}
+          {{- if .Values.balancer.logoUrl }}
+          - name: MULTI_JUICER_BALANCER_LOGO_URL
+            value: {{ .Values.balancer.logoUrl | quote }}
+          {{- end }}
           - name: LOG_LEVEL
             value: {{ .Values.logLevel | default "info" | quote }}
           {{- if .Values.config.juiceShop.llm.enabled }}

--- a/helm/multi-juicer/values.yaml
+++ b/helm/multi-juicer/values.yaml
@@ -90,6 +90,10 @@ metrics:
     # -- If you use the kube-prometheus-stack helm chart, the default label looked for is `release=<kube-prometheus-release-name>
     labels: {}
 
+balancer:
+  # -- Optional URL to a custom logo for the MultiJuicer balancer UI. If this points to an external host, update `contentSecurityPolicy` to allow that image source.
+  logoUrl: ""
+
 config:
   # -- Specifies how many JuiceShop instances MultiJuicer should start at max. Set to -1 to remove the max Juice Shop instance cap
   maxInstances: 10

--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -50,9 +50,14 @@ type Config struct {
 	MaxInstances          int             `json:"maxInstances"`
 	TeamPasscodeLength    int             `json:"teamPasscodeLength"`
 	CookieConfig          CookieConfig    `json:"cookie"`
+	BalancerConfig        BalancerConfig  `json:"balancer"`
 	AdminConfig           *AdminConfig
 	ContentSecurityPolicy string
 	Cleanup               CleanupConfig
+}
+
+type BalancerConfig struct {
+	LogoURL string `json:"logoUrl"`
 }
 
 type CleanupConfig struct {
@@ -254,6 +259,7 @@ func New() *Bundle {
 	config.CookieConfig.SigningKey = cookieSigningKey
 	config.AdminConfig = &AdminConfig{Password: adminPasswordKey}
 	config.ContentSecurityPolicy = os.Getenv("MULTI_JUICER_CONTENT_SECURITY_POLICY")
+	config.BalancerConfig.LogoURL = os.Getenv("MULTI_JUICER_BALANCER_LOGO_URL")
 
 	if config.JuiceShopConfig.LLM.Enabled {
 		llmAPIKey := os.Getenv("LLM_API_KEY")

--- a/internal/routes/public/staticFiles.go
+++ b/internal/routes/public/staticFiles.go
@@ -20,6 +20,11 @@ func handleStaticFiles(bundle *bundle.Bundle) http.Handler {
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/multi-juicer/multi-juicer.svg" && bundle.Config.BalancerConfig.LogoURL != "" {
+			http.Redirect(w, r, bundle.Config.BalancerConfig.LogoURL, http.StatusFound)
+			return
+		}
+
 		for _, route := range frontendRoutePatterns {
 			if route.MatchString(r.URL.Path) {
 				// Set Content Security Policy header for index.html if configured

--- a/internal/routes/public/staticFiles_test.go
+++ b/internal/routes/public/staticFiles_test.go
@@ -100,4 +100,20 @@ func TestStaticFileHandler(t *testing.T) {
 
 		assert.Empty(t, rr.Header().Get("Content-Security-Policy"))
 	})
+
+	t.Run("should redirect the balancer logo when a custom logo URL is configured", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", "/multi-juicer/multi-juicer.svg", nil)
+		rr := httptest.NewRecorder()
+
+		server := http.NewServeMux()
+		bundle := testutil.NewTestBundle()
+		bundle.StaticAssetsDirectory = testutil.UIBuildDir()
+		bundle.Config.BalancerConfig.LogoURL = "/multi-juicer/custom/logo.png"
+		AddRoutes(server, bundle)
+
+		server.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusFound, rr.Code)
+		assert.Equal(t, "/multi-juicer/custom/logo.png", rr.Header().Get("Location"))
+	})
 }


### PR DESCRIPTION
Closes #222.

This adds a small Helm-driven option for replacing the MultiJuicer balancer logo without changing the default UI:

- adds `balancer.logoUrl` to the chart values
- passes it to the app as `MULTI_JUICER_BALANCER_LOGO_URL` only when set
- redirects the existing `/multi-juicer/multi-juicer.svg` logo request to the configured URL
- keeps the default behavior unchanged when no custom logo is configured

If the logo points to an external host, `contentSecurityPolicy` still needs to allow that image source.

Checks run locally:

- `npm ci --ignore-scripts --cache /tmp/multi-juicer-npm-cache`
- `npm run build`
- `npm run lint`
- `npm test -- --run`
- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `go tool staticcheck ./...`
- `go fix ./...`
- `helm template` with and without `balancer.logoUrl`
- `git diff --check`