### PR TITLE
Add French language support

### DIFF
--- a/ui/src/translations/fr-FR.ts
+++ b/ui/src/translations/fr-FR.ts
@@ -1,0 +1,171 @@
+export default {
+  getting_started_text:
+    "Choisis un nom d'équipe qui nous permettra de te reconnaître. Si tu souhaites faire équipe avec d'autres personnes, tu peux les rejoindre en choisissant le même nom d'équipe.",
+  getting_started: "C'est parti !",
+  join_failed_text: "Impossible de créer / rejoindre l'équipe.",
+  teamname: "Nom d'équipe",
+  teamname_validation_constraints:
+    "Un nom d'équipe doit contenir au moins 3 caractères et n'être constitué que de lettres minuscules, de chiffres, et de tirets ('-').",
+  create_or_join_team_label: "Créer / rejoindre l'équipe",
+  change_language: "Changer la langue",
+  "navigation.team": "Ton équipe",
+  "navigation.scoreboard": "Tableau de score",
+  joining_team: "Rejoindre l'équipe {team}",
+  joining_failed:
+    "Impossible de rejoindre l'équipe. Es-tu certain·e d'avoir le bon mot de passe ?",
+  team_passcode: "Mot de passe de l'équipe",
+  join_team: "Rejoindre l'équipe",
+  logged_in_as: "Connecté·e en tant que",
+  log_out: "Déconnexion",
+  reset_passcode: "Réinitialiser le mot de passe",
+  passcode_explanation:
+    "Partage le lien d'invitation ou le mot de passe avec les membres de ton équipe afin qu'ils puissent te rejoindre.",
+  join_link_label: "Lien d'invitation",
+  copy_join_link: "Copier le lien d'invitation",
+  copy_link_button: "Copier le lien d'invitation",
+  join_link_copied: "Lien d'invitation copié dans le presse-papier",
+  passcode_label: "Ou utilise le même nom d'équipe et le mot de passe suivant",
+  passcode: "Mot de passe",
+  reset_passcode_confirmation:
+    "Es-tu certain·e de vouloir réinitialiser le mot de passe ? Cela va entraîner l'invalidation de tous les liens d'invitation et mots de passes partagés précédemment.",
+  instance_status_start_hacking: "Débuter le piratage",
+  instance_status_starting: "Démarrage d'une instance du Juice Shop",
+  "admin_table.table_header": "Équipes actives",
+  "admin_table.created": "Créée",
+  "admin_table.restarting": "Redémarrage...",
+  "admin_table.restart": "Redémarrer",
+  "admin_table.deleting": "Suppression...",
+  "admin_table.delete": "Supprimer",
+  "admin_table.latUsed": "Dernière utilisation remontant à",
+  "admin_table.no_teams": "Pas d'équipes actives",
+  "admin_table.instance_status.up_and_running": "opérationnelle 🟢",
+  "admin_table.instance_status.down": "en panne ⚠️",
+  "admin_table.cheat_score": "Scores de triche",
+  "admin_table.cheat_score_tooltip":
+    "Ce score indique que des défis sont résolus plus vite que d'habitude. Il suggère (sans toutefois confirmer) que de la triche a lieu. Pour en savoir plus, clique ici.",
+  "admin_table.no_cheat_score": "Aucun score de triche",
+  "admin_table.cheat_score_graph_not_available_yet":
+    "Le graphe des scores de triche sera disponible lorsque plus d'un défi aura été résolu.",
+  "admin_table.reset_passcode": "Réinitialiser le mot de passe de l'équipe",
+  "admin_table.new_passcode": 'Mot de passe de l\'équipe "{team}" mis à jour',
+  "cheat_score_graph.title": "Historique des scores de triche",
+  "cheat_score_graph.not_enough_data":
+    "Pas assez de données pour produire le graphe",
+  "cheat_score_graph.x_axis_label": "Défis résolus →",
+  "cheat_score_graph.expand": "Maximiser",
+  "cheat_score_graph.close": "Fermer",
+  updating_score: "Ton score est en train d'être calculé...",
+  score_overview: "Aperçu du score",
+  team_score:
+    "Ton équipe est placée {position} sur {totalTeams} avec {solvedChallengeCount} défis résolus.",
+  "navigation.admin": "Administration",
+  "activity.title": "Activité en direct",
+  "activity.team_joined": "{team} a rejoint la partie",
+  "activity.solved_challenge": "{team} a résolu {challenge} (+{points} pts)",
+  "activity.no_events": "Pas d'activité récente.",
+  "team_detail.loading": "Chargement des détails de l'équipe...",
+  "team_detail.rank": "Place {position} sur {totalTeams}",
+  "team_detail.solved_challenges": "Défis résolus",
+  "team_detail.no_solves": "Aucune défi résolu pour l'instant.",
+  "team_detail.header.challenge": "Défi",
+  "team_detail.header.difficulty": "Difficulté",
+  "team_detail.header.solved": "Résolu",
+  "challenge_detail.loading": "Chargement des détails du défi...",
+  "challenge_detail.solves_title": "Résolutions",
+  "challenge_detail.no_one_solved": "Personne n'a encore résolu ce défi.",
+  "challenge_detail.header.team": "Équipe",
+  "challenge_detail.header.solved": "Résolu",
+  "scoreboard.loading": "Chargement de l'aperçu du score...",
+  "scoreboard.error":
+    "L'aperçu du score n'a pas pu être chargé. Essaye à nouveau...",
+  "scoreboard.header.team": "Équipe",
+  "scoreboard.header.score": "Score",
+  "scoreboard.header.challenges": "Défis",
+  difficulty: "Difficulté : {difficulty}/6",
+  logout_confirmation:
+    "Es-tu certain·e de vouloir te déconnecter ? Si tu n'as pas le mot de passe, tu ne pourras plus rejoindre l'équipe.",
+  logout_success: "Déconnexion réussie",
+  passcode_copied: "Mot de passe copié dans le presse-papier",
+  passcode_reset_success: "Mot de passe réinitialisé",
+  passcode_reset_error: "La réinitialisation du mot de passe a échoué.",
+  passcode_updated_explanation_admin:
+    "Copie et partage ce mot de passe avec les membres de l'équipe.",
+  admin_delete_team_confirmation:
+    'Es-tu certain·e de vouloir supprimer l\'équipe "{team}" ?',
+  admin_restart_team_confirmation:
+    'Es-tu certain·e de vouloir redémarrer l\'équipe "{team}" ?',
+  admin_reset_passcode_confirmation:
+    'Es-tu certain·e de vouloir réinitialiser le mot de passe de l\'équipe "{team}" ?',
+  instance_status_not_found:
+    "Aucune instance correspondant à l'équipe. Tu peux la recréer et te reconnectant.",
+  clipboard_not_available:
+    "Le presse-papier n'est pas disponible. Merci de copier le mot de passe manuellement.",
+  "admin.notification.title":
+    "Envoyer un message à tous·tes les utilisateurs·rices",
+  "admin.notification.description":
+    "Les messages sont montrés à tous·tes les utilisateurs·trices dans l'interface MultiJuicer. Ils permettent d'informer les utilisateurs·trices de mises à jour ou de problèmes importants.",
+  "admin.notification.placeholder": "Compose un message...",
+  "admin.notification.characters_remaining": "{count} caractères restant",
+  "admin.notification.markdown_supported":
+    "La syntaxe de base du Markdown est supportée.",
+  "admin.notification.error.too_long":
+    "Le message est trop long (128 caractères maximum)",
+  "admin.notification.success": "Message mis à jour",
+  "admin.notification.cleared": "Message effacé",
+  "admin.notification.error": "Le message n'a pas pu être mis à jour.",
+  "admin.notification.submitting": "Mise à jour...",
+  "admin.notification.submit": "Envoyer le message",
+  "admin.notification.clear": "Effacer le message",
+  "admin.notification.end_date.label":
+    "Date de fin de l'évènement (optionnelle)",
+  "admin.notification.end_date.hint_future": "dans {time}",
+  "admin.notification.end_date.hint_past": "Cette date est dans le passé.",
+  "notification.event_ended": "L'évènement est terminé.",
+  "ctf.game_clock.title": "Horloge de jeu",
+  "ctf.game_clock.ended": "L'évènement est terminé.",
+  "ctf.loading.geodata": "CHARGEMENT DES GÉODONNÉES...",
+  "ctf.loading.initializing": "Initialisation...",
+  "ctf.loading.challenges": "Chargement des défis...",
+  "ctf.loading.theme_colors": "Chargement des couleurs du thème...",
+  "ctf.loading.world_data": "Chargement des données du globe...",
+  "ctf.globe.error": "ERREUR : {error}",
+  "ctf.info_panel.title": "CTF MultiJuicer",
+  "ctf.info_panel.logo_alt": "Logo MultiJuicer",
+  "ctf.teams_panel.title": "ÉQUIPES",
+  "ctf.teams_panel.loading": "Chargement des équipes...",
+  "ctf.teams_panel.error": "Erreur : {error}",
+  "ctf.teams_panel.score_solves":
+    "{score}pts - {solveCount, plural, one {# résolution} other {# résolutions}}",
+  "ctf.activity_panel.title": "ACTIVITÉ EN DIRECT",
+  "ctf.activity_panel.loading": "Chargement de l'activité...",
+  "ctf.activity_panel.error": "Erreur : {error}",
+  "ctf.activity_panel.challenge_solved":
+    "{team} a résolu {challenge} (+{points} pts)",
+  "ctf.activity_panel.challenge_solved_country":
+    "{team} a résolu {challenge} ({country}) (+{points} pts)",
+  "ctf.time_ago.seconds":
+    "{count, plural, one {il y a # seconde} other {il y a # secondes}}",
+  "ctf.time_ago.minutes":
+    "{count, plural, one {il y a # minute} other {il y a # minutes}}",
+  "ctf.time_ago.hours":
+    "{count, plural, one {il y a # heure} other {il y a # heures}}",
+  "ctf.time_ago.days":
+    "{count, plural, one {il y a # jour} other {il y a # jours}}",
+  "ctf.challenges_panel.title": "DÉFIS ({count})",
+  "ctf.challenge.unassigned": "Non assigné",
+  "ctf.challenge.unsolved": "Non résolu",
+  "ctf.challenge.solve_count":
+    "{solveCount, plural, one {# résolution} other {# résolutions}}",
+  "ctf.challenge_detail.back": "← retour",
+  "ctf.challenge_detail.solves_label": "Résolutions :",
+  "ctf.challenge_detail.loading_solves": "Chargement des résolutions...",
+  "ctf.challenge_detail.error": "Erreur : {error}",
+  "ctf.challenge_detail.no_solves": "Pas encore de résolutions",
+  "ctf.challenge_detail.solved_just_now": "résolu à l'instant",
+  "ctf.challenge_detail.solved_mins_ago":
+    "résolu il y a {count, plural, one {# minute} other {# minutes}}",
+  "ctf.challenge_detail.solved_hours_ago":
+    "résolu il y a {count, plural, one {# heure} other {# heures}}",
+  "ctf.challenge_detail.solved_days_ago":
+    "résolu il y a {count, plural, one {# jour} other {# jours}}",
+};

--- a/ui/src/translations/index.ts
+++ b/ui/src/translations/index.ts
@@ -14,6 +14,13 @@ const availableLanguages: Language[] = [
     messageLoader: () => Promise.resolve({ default: {} }),
   },
   {
+    flag: "🇫🇷",
+    name: "French",
+    key: "fr-FR",
+    messageLoader: () =>
+      import("./fr-FR") as Promise<{ default: Record<string, string> }>,
+  },
+  {
     flag: "🇩🇪",
     name: "German",
     key: "de-DE",


### PR DESCRIPTION
### Description

Add support for the French language.

### AI Tool Disclosure

- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`
