### PR TITLE
Update LLM API URL in config-map.yaml

### DIFF
--- a/helm/multi-juicer/templates/deployment.yaml
+++ b/helm/multi-juicer/templates/deployment.yaml
@@ -68,6 +68,8 @@ spec:
               secretKeyRef:
                 name: {{ .Values.config.juiceShop.llm.existingSecret.name }}
                 key: {{ .Values.config.juiceShop.llm.existingSecret.key }}
+          - name: LLM_API_URL
+            value: {{ .Values.config.juiceShop.llm.apiUrl | quote }}
           {{- end }}
           ports:
             - name: http

--- a/helm/multi-juicer/templates/deployment.yaml
+++ b/helm/multi-juicer/templates/deployment.yaml
@@ -68,8 +68,6 @@ spec:
               secretKeyRef:
                 name: {{ .Values.config.juiceShop.llm.existingSecret.name }}
                 key: {{ .Values.config.juiceShop.llm.existingSecret.key }}
-          - name: LLM_API_URL
-            value: {{ .Values.config.juiceShop.llm.apiUrl | quote }}
           {{- end }}
           ports:
             - name: http

--- a/helm/multi-juicer/templates/juice-shop/config-map.yaml
+++ b/helm/multi-juicer/templates/juice-shop/config-map.yaml
@@ -8,7 +8,7 @@ data:
   multi-juicer.yaml: |-
     {{- $config := deepCopy .Values.config.juiceShop.config }}
     {{- if .Values.config.juiceShop.llm.enabled }}
-    {{- $chatBot := dict "chatBot" (dict "model" .Values.config.juiceShop.llm.model "llmApiUrl" (printf "http://multijuicer-private.%s.svc.cluster.local" .Release.Namespace)) }}
+    {{- $chatBot := dict "chatBot" (dict "model" .Values.config.juiceShop.llm.model "llmApiUrl" .Values.config.juiceShop.llm.apiUrl) }}
     {{- $_ := merge ($config).application $chatBot }}
     {{- end }}
     {{ $config | toYaml | nindent 4 }}


### PR DESCRIPTION
### Description

Configuring the option `config.juiceShop.llm.apiUrl` does not work. 
The `juice-shop-config` always configures the `llmApiUrl` like this:
```yaml
llmApiUrl: http://multijuicer-private.multi-juicer.svc.cluster.local
```

### AI Tool Disclosure

- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
    - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
    - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`
