### PR TITLE
Add Hetzner guide with scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ ui/build/
 *.test
 
 .claude/
+/guides/hetzner/.multi-juicer-hetzner/

--- a/guides/hetzner/hetzner.md
+++ b/guides/hetzner/hetzner.md
@@ -203,6 +203,26 @@ If `LLM_API_KEY` is **not** set, the script prints a warning and leaves the gate
 
 > **Cost tip:** the gateway does not enforce per-team rate limits — set a spending cap at your LLM provider before the event.
 
+### LLM connectivity preflight
+
+Before installing MultiJuicer, `setup.sh` runs a small probe *from the Hetzner VM itself* (via SSH) that:
+
+1. `curl`s `${LLM_API_URL}/models` with a 15 s timeout and accepts any 2xx-4xx as "network path works" (a 401 is fine here — it means the provider replied).
+2. If `LLM_API_KEY` is set, lists the provider's model catalog with a Bearer token and checks that `LLM_MODEL` is included.
+
+Both checks are **non-fatal** — the install continues either way — but they print a bright yellow warning and the final summary tags the LLM line with `(WARNING: ...)`. This is the most reliable diagnosis for the classic *"local Juice Shop chatbot works, on Hetzner it takes forever and then errors out"* symptom: the outgoing network path is fine (Hetzner Cloud firewalls only filter **inbound** traffic — outbound is unrestricted), and the culprit is almost always an upstream issue — most often a **wrong model id**. When Juice Shop asks the provider for a model that the account cannot access, the request hangs on a slow 4xx, Juice Shop retries, and eventually surfaces as a chatbot error in the UI.
+
+If you see the warning, reproduce and diagnose manually from the VM:
+
+```bash
+export KUBECONFIG="$(pwd)/.multi-juicer-hetzner/kubeconfig.yaml"
+ssh -i ./.multi-juicer-hetzner/id_ed25519 root@<IP> \
+  curl -sS -H "Authorization: Bearer $LLM_API_KEY" \
+  https://openrouter.ai/api/v1/models | jq '.data | map(.id)' | grep -i <partial-model-name>
+```
+
+Then re-run with a valid id, e.g. `LLM_MODEL="<the-id-you-just-found>" ./setup.sh` — the script is idempotent and only rewrites the LLM Helm values.
+
 ## Sizing notes
 
 The defaults target a small event on the cheapest sensible Hetzner box (`cpx22`: 2 vCPU / 4 GB RAM / 40 GB SSD). The math behind `MAX_INSTANCES=10`:
@@ -225,3 +245,4 @@ Guidelines for scaling up:
 - **Browser shows "Kubernetes Ingress Controller Fake Certificate"** — cert-manager hasn't finished the ACME challenge yet. Reload after ~30–60 s.
 - **Pods stuck `Pending`** — the node ran out of schedulable CPU or memory. On the default `cpx22`, CPU is the tightest resource, so this typically happens when `MAX_INSTANCES` is raised without also picking a bigger `SERVER_TYPE`. Choose a bigger `SERVER_TYPE` (e.g. `cpx31` / `cpx41`) and re-run `setup.sh`.
 - **`kubectl` / `helm` time out with `dial tcp <ip>:6443: ... failed to respond`** — the Hetzner firewall is not letting your machine reach the Kubernetes API. `setup.sh` opens tcp/6443 only for the public IPv4 it detects via `api.ipify.org` when it runs, so if your public IP has changed since the last run (new network, VPN toggled, ISP-reassigned dynamic address), just re-run `setup.sh` — the firewall rules are re-applied every run and the current IP will be allowed. Behind a shared/corporate egress or on a dynamic range, set `ADMIN_CIDR` explicitly (e.g. `ADMIN_CIDR=203.0.113.0/24 ./setup.sh`).
+- **JuiceShop chatbot works locally but hangs / errors out on Hetzner** — this is almost never a firewall issue: Hetzner Cloud firewalls only filter *inbound* traffic, and `setup.sh`'s LLM preflight (see [LLM connectivity preflight](#llm-connectivity-preflight)) verifies from the VM that `${LLM_API_URL}/models` responds and that `LLM_MODEL` is actually listed by the provider. If the preflight prints a `!! ...` warning, the fix is upstream: fix `LLM_API_URL`, pick a model your account can access (see the provider dashboard), or bump a spending cap that the free tier has already exhausted, then re-run `setup.sh`.

--- a/guides/hetzner/hetzner.md
+++ b/guides/hetzner/hetzner.md
@@ -1,6 +1,6 @@
 # Example Setup with Hetzner Cloud
 
-This guide sets up a MultiJuicer cluster on a single [Hetzner Cloud](https://www.hetzner.com/cloud) server, sized for up to **10 teams**, reachable via public Internet on your own domain over **HTTPS** (Let's Encrypt).
+This guide sets up a MultiJuicer cluster on a single [Hetzner Cloud](https://www.hetzner.com/cloud) server, sized for up to **30 teams**, reachable via public Internet on your own domain over **HTTPS** (Let's Encrypt).
 
 The domain is expected to be registered/managed at **your existing DNS provider** (e.g. [Strato](https://www.strato.de), GoDaddy, Namecheap, Cloudflare, ...). This guide does **not** move your domain to Hetzner — you just point a single `A` record at the freshly-created Hetzner VM.
 
@@ -9,7 +9,7 @@ The setup is intentionally **throw-away**: everything lives on one VM, so once y
 - [`setup.sh`](./setup.sh) — provisions everything from scratch
 - [`teardown.sh`](./teardown.sh) — deletes every Hetzner resource created by `setup.sh`
 
-**WARNING:** The default server type used here (`cpx22`, 2 vCPU / 4 GB RAM / 40 GB SSD) costs roughly **€6/month** (~€0.01/h) on Hetzner Cloud. Delete the resources with `teardown.sh` when you no longer need them.
+**WARNING:** The default server type used here (`cpx32`, 4 vCPU / 8 GB RAM / 80 GB SSD, Hetzner's newer AMD generation) costs **€0.0677/h** on Hetzner Cloud, capped at **€42.23/month** on the monthly plan (per Hetzner's published price sheet). Delete the resources with `teardown.sh` when you no longer need them.
 
 ## What the script creates
 
@@ -17,7 +17,7 @@ The setup is intentionally **throw-away**: everything lives on one VM, so once y
 |--------------------------------|----------------------|------------------------------------------------------------------|
 | SSH key (`ed25519`)            | local + Hetzner Cloud | Login key for the fresh VM                                       |
 | Firewall (`multi-juicer-fw`)   | Hetzner Cloud        | Allows inbound tcp/22, tcp/80, tcp/443 (world) and tcp/6443 (k8s API, restricted to your public IP) |
-| Server (`multi-juicer`, cpx22) | Hetzner Cloud        | Single-node cluster host                                         |
+| Server (`multi-juicer`, cpx32) | Hetzner Cloud        | Single-node cluster host                                         |
 | k3s (Traefik disabled)         | on the VM            | Lightweight Kubernetes                                           |
 | ingress-nginx                  | in-cluster           | HTTP(S) entry point (matches chart default `ingressClassName`)   |
 | cert-manager + ClusterIssuer   | in-cluster           | Automatic Let's Encrypt certificate                              |
@@ -48,9 +48,9 @@ export DOMAIN="juicy.example.com"    # any subdomain of a domain you control
 export EMAIL="you@example.com"       # used for Let's Encrypt registration
 
 # Optional overrides:
-# export SERVER_TYPE=cpx22           # ~10 teams. Use cpx31/cpx41 (or ccx23 for dedicated CPUs) for larger events.
+# export SERVER_TYPE=cpx32           # ~30 teams. Drop to cpx22 for tiny events, or bump to cpx42 / cpx52 (or ccx23 for dedicated CPUs) for larger ones.
 # export SERVER_LOCATION=nbg1        # nbg1 | fsn1 | hel1 | ash | hil | sin
-# export MAX_INSTANCES=10            # caps the number of JuiceShop instances
+# export MAX_INSTANCES=30            # caps the number of JuiceShop instances
 # export REPLICAS=2                  # MultiJuicer balancer replicas (production checklist recommends >=2)
 # export DNS_TIMEOUT=1800            # seconds to wait for DNS to propagate
 # export ADMIN_CIDR=1.2.3.4/32       # CIDR allowed to reach the k8s API (tcp/6443).
@@ -182,7 +182,7 @@ The script already applies the recommendations from [`guides/production-notes/pr
 - **`cookie.secure=true`** — the balancer session cookie is only sent over HTTPS (safe here because everything runs behind Let's Encrypt).
 - **Persistent `cookie.cookieParserSecret`** — a 24-char random secret is generated on the first run and stored in `./.multi-juicer-hetzner/cookie-parser-secret`. Re-runs reuse it, so `helm upgrade` no longer invalidates all team sessions. Delete the file if you want to force a rotation.
 - **`replicas=2`** — two balancer pods on the single node, so a pod crash or rolling upgrade does not take the whole event offline. Override with `REPLICAS=<n>`. (Note: the node itself is a single VM — for real HA you would need multiple nodes.)
-- **`config.maxInstances=10`** — matches the ~10 team sizing of the default `cpx22`. Override with `MAX_INSTANCES` (and pick a bigger `SERVER_TYPE` if you raise it much).
+- **`config.maxInstances=30`** — matches the ~30 team sizing of the default `cpx32`. Override with `MAX_INSTANCES` (and pick a bigger `SERVER_TYPE` if you raise it much).
 
 ## AI / LLM challenges
 
@@ -225,15 +225,16 @@ Then re-run with a valid id, e.g. `LLM_MODEL="<the-id-you-just-found>" ./setup.s
 
 ## Sizing notes
 
-The defaults target a small event on the cheapest sensible Hetzner box (`cpx22`: 2 vCPU / 4 GB RAM / 40 GB SSD). The math behind `MAX_INSTANCES=10`:
+The defaults target a mid-sized event on a `cpx32` (4 vCPU / 8 GB RAM / 80 GB SSD, Hetzner's newer AMD generation). The math behind `MAX_INSTANCES=30`:
 
 - Per Juice Shop pod (from the upstream project's stated **minimum** system requirements): **256 MB RAM**, **200 millicpu**, **300 MB disk**. Recommended is 384 MB / 400 millicpu / 800 MB disk.
-- k3s + ingress-nginx + cert-manager + 2 MultiJuicer balancer replicas reserve roughly **1.1 vCPU** and **1.4 GB RAM** on the node, leaving about **900 mCPU**, **2.6 GB RAM** and ~30 GB free disk for Juice Shop pods.
-- CPU is the tightest resource: 900 mCPU / 200 mCPU ≈ 4–5 pods at Juice Shop's stated minimum, or ~6 pods at the chart's default request of 150 mCPU. Since teams are mostly idle and no CPU **limits** are set, a soft cap of 10 is a realistic compromise. RAM (~10 pods at 256 MB) and disk (>90 pods at 300 MB) are not the bottleneck.
+- k3s + ingress-nginx + cert-manager + 2 MultiJuicer balancer replicas reserve roughly **1.1 vCPU** and **1.4 GB RAM** on the node, leaving about **2.9 vCPU**, **6.6 GB RAM** and ~70 GB free disk for Juice Shop pods.
+- CPU is the tightest resource: 2900 mCPU / 200 mCPU ≈ 14 pods at Juice Shop's stated minimum, or ~19 pods at the chart's default request of 150 mCPU. Since teams are mostly idle and no CPU **limits** are set, a soft cap of 30 is a realistic compromise. RAM (~25 pods at 256 MB) and disk (>200 pods at 300 MB) are not the bottleneck.
 
-Guidelines for scaling up:
+Guidelines for scaling up or down:
 
-- Want more than ~10 teams? Bump both variables together, e.g. `SERVER_TYPE=cpx31` (4 vCPU / 8 GB) with `MAX_INSTANCES=25`, or the previous `SERVER_TYPE=cpx41` (8 vCPU / 16 GB) with `MAX_INSTANCES=50`.
+- Small event (up to ~10 teams)? Drop to `SERVER_TYPE=cpx22` (2 vCPU / 4 GB, ~€6/month) with `MAX_INSTANCES=10`.
+- Want more than ~30 teams? Bump both variables together, e.g. `SERVER_TYPE=cpx42` (8 vCPU / 16 GB) with `MAX_INSTANCES=50`, or `SERVER_TYPE=cpx52` (16 vCPU / 32 GB) with `MAX_INSTANCES=100`.
 - If you expect heavy concurrent traffic per team (e.g. teams actively hacking rather than reading), switch to a **dedicated-CPU** type (e.g. `ccx23` / `ccx33`) via `SERVER_TYPE` — shared-vCPU plans like `cpx*` can throttle under sustained load.
 - To hard-cap the number of teams, use `MAX_INSTANCES`. See the chart's `config.maxInstances` value in [`helm/multi-juicer/values.yaml`](../../helm/multi-juicer/values.yaml) for the full list of tunables.
 
@@ -243,6 +244,6 @@ Guidelines for scaling up:
 - **Wrong IP resolved / stale record** — if you re-created the VM, `DOMAIN` may still resolve to the previous IP because of TTL caching at your provider or resolver. Update the record at your provider, wait for the old TTL to expire, and re-run `setup.sh`.
 - **Certificate stuck in `Ready: False`** — check `kubectl describe certificate multi-juicer-tls` and `kubectl -n cert-manager logs deploy/cert-manager`. The most common cause is that DNS hasn't propagated to the Let's Encrypt validators yet; wait a minute and retry. A stale `AAAA` record pointing at a non-existent IPv6 host also breaks the ACME HTTP-01 challenge — delete or update it.
 - **Browser shows "Kubernetes Ingress Controller Fake Certificate"** — cert-manager hasn't finished the ACME challenge yet. Reload after ~30–60 s.
-- **Pods stuck `Pending`** — the node ran out of schedulable CPU or memory. On the default `cpx22`, CPU is the tightest resource, so this typically happens when `MAX_INSTANCES` is raised without also picking a bigger `SERVER_TYPE`. Choose a bigger `SERVER_TYPE` (e.g. `cpx31` / `cpx41`) and re-run `setup.sh`.
+- **Pods stuck `Pending`** — the node ran out of schedulable CPU or memory. On the default `cpx32`, CPU is the tightest resource, so this typically happens when `MAX_INSTANCES` is raised without also picking a bigger `SERVER_TYPE`. Choose a bigger `SERVER_TYPE` (e.g. `cpx42` / `cpx52` / `ccx33`) and re-run `setup.sh`.
 - **`kubectl` / `helm` time out with `dial tcp <ip>:6443: ... failed to respond`** — the Hetzner firewall is not letting your machine reach the Kubernetes API. `setup.sh` opens tcp/6443 only for the public IPv4 it detects via `api.ipify.org` when it runs, so if your public IP has changed since the last run (new network, VPN toggled, ISP-reassigned dynamic address), just re-run `setup.sh` — the firewall rules are re-applied every run and the current IP will be allowed. Behind a shared/corporate egress or on a dynamic range, set `ADMIN_CIDR` explicitly (e.g. `ADMIN_CIDR=203.0.113.0/24 ./setup.sh`).
 - **JuiceShop chatbot works locally but hangs / errors out on Hetzner** — this is almost never a firewall issue: Hetzner Cloud firewalls only filter *inbound* traffic, and `setup.sh`'s LLM preflight (see [LLM connectivity preflight](#llm-connectivity-preflight)) verifies from the VM that `${LLM_API_URL}/models` responds and that `LLM_MODEL` is actually listed by the provider. If the preflight prints a `!! ...` warning, the fix is upstream: fix `LLM_API_URL`, pick a model your account can access (see the provider dashboard), or bump a spending cap that the free tier has already exhausted, then re-run `setup.sh`.

--- a/guides/hetzner/hetzner.md
+++ b/guides/hetzner/hetzner.md
@@ -60,7 +60,7 @@ export EMAIL="you@example.com"       # used for Let's Encrypt registration
 # When unset, the gateway stays off and the chatbot is not available to teams.
 # See guides/llm/llm.md for background.
 # export LLM_API_KEY="sk-..."                       # your upstream LLM API key
-# export LLM_MODEL="qwen/qwen3.5-9b"                # default shown
+# export LLM_MODEL="inclusionai/ling-3.0-flash-fin:free" # default shown
 # export LLM_API_URL="https://openrouter.ai/api/v1" # any OpenAI-compatible base URL
 
 cd guides/hetzner
@@ -192,7 +192,7 @@ To enable it in this Hetzner setup, set `LLM_API_KEY` (and optionally `LLM_MODEL
 
 ```bash
 export LLM_API_KEY="sk-..."                       # OpenAI / OpenRouter / Ollama key
-export LLM_MODEL="qwen/qwen3.5-9b"                # any model your provider serves
+export LLM_MODEL="inclusionai/ling-3.0-flash-fin:free" # any model your provider serves
 export LLM_API_URL="https://openrouter.ai/api/v1" # any OpenAI-compatible base URL
 ./setup.sh
 ```

--- a/guides/hetzner/hetzner.md
+++ b/guides/hetzner/hetzner.md
@@ -1,6 +1,6 @@
 # Example Setup with Hetzner Cloud
 
-This guide sets up a MultiJuicer cluster on a single [Hetzner Cloud](https://www.hetzner.com/cloud) server, sized for up to **30 teams**, reachable via public Internet on your own domain over **HTTPS** (Let's Encrypt).
+This guide sets up a MultiJuicer cluster on a single [Hetzner Cloud](https://www.hetzner.com/cloud) server, sized for up to **20 teams**, reachable via public Internet on your own domain over **HTTPS** (Let's Encrypt).
 
 The domain is expected to be registered/managed at **your existing DNS provider** (e.g. [Strato](https://www.strato.de), GoDaddy, Namecheap, Cloudflare, ...). This guide does **not** move your domain to Hetzner — you just point a single `A` record at the freshly-created Hetzner VM.
 
@@ -48,9 +48,9 @@ export DOMAIN="juicy.example.com"    # any subdomain of a domain you control
 export EMAIL="you@example.com"       # used for Let's Encrypt registration
 
 # Optional overrides:
-# export SERVER_TYPE=cpx32           # ~30 teams. Drop to cpx22 for tiny events, or bump to cpx42 / cpx52 (or ccx23 for dedicated CPUs) for larger ones.
+# export SERVER_TYPE=cpx32           # ~20 teams. Drop to cpx22 for tiny events, or bump to cpx42 / cpx52 (or ccx23 for dedicated CPUs) for larger ones.
 # export SERVER_LOCATION=nbg1        # nbg1 | fsn1 | hel1 | ash | hil | sin
-# export MAX_INSTANCES=30            # caps the number of JuiceShop instances
+# export MAX_INSTANCES=20            # caps the number of JuiceShop instances
 # export REPLICAS=2                  # MultiJuicer balancer replicas (production checklist recommends >=2)
 # export DNS_TIMEOUT=1800            # seconds to wait for DNS to propagate
 # export ADMIN_CIDR=1.2.3.4/32       # CIDR allowed to reach the k8s API (tcp/6443).
@@ -182,7 +182,7 @@ The script already applies the recommendations from [`guides/production-notes/pr
 - **`cookie.secure=true`** — the balancer session cookie is only sent over HTTPS (safe here because everything runs behind Let's Encrypt).
 - **Persistent `cookie.cookieParserSecret`** — a 24-char random secret is generated on the first run and stored in `./.multi-juicer-hetzner/cookie-parser-secret`. Re-runs reuse it, so `helm upgrade` no longer invalidates all team sessions. Delete the file if you want to force a rotation.
 - **`replicas=2`** — two balancer pods on the single node, so a pod crash or rolling upgrade does not take the whole event offline. Override with `REPLICAS=<n>`. (Note: the node itself is a single VM — for real HA you would need multiple nodes.)
-- **`config.maxInstances=30`** — matches the ~30 team sizing of the default `cpx32`. Override with `MAX_INSTANCES` (and pick a bigger `SERVER_TYPE` if you raise it much).
+- **`config.maxInstances=20`** — matches the ~20 team sizing of the default `cpx32`. Override with `MAX_INSTANCES` (and pick a bigger `SERVER_TYPE` if you raise it much).
 
 ## AI / LLM challenges
 
@@ -225,16 +225,16 @@ Then re-run with a valid id, e.g. `LLM_MODEL="<the-id-you-just-found>" ./setup.s
 
 ## Sizing notes
 
-The defaults target a mid-sized event on a `cpx32` (4 vCPU / 8 GB RAM / 80 GB SSD, Hetzner's newer AMD generation). The math behind `MAX_INSTANCES=30`:
+The defaults target a mid-sized event on a `cpx32` (4 vCPU / 8 GB RAM / 80 GB SSD, Hetzner's newer AMD generation). The math behind `MAX_INSTANCES=20`:
 
 - Per Juice Shop pod (from the upstream project's stated **minimum** system requirements): **256 MB RAM**, **200 millicpu**, **300 MB disk**. Recommended is 384 MB / 400 millicpu / 800 MB disk.
 - k3s + ingress-nginx + cert-manager + 2 MultiJuicer balancer replicas reserve roughly **1.1 vCPU** and **1.4 GB RAM** on the node, leaving about **2.9 vCPU**, **6.6 GB RAM** and ~70 GB free disk for Juice Shop pods.
-- CPU is the tightest resource: 2900 mCPU / 200 mCPU ≈ 14 pods at Juice Shop's stated minimum, or ~19 pods at the chart's default request of 150 mCPU. Since teams are mostly idle and no CPU **limits** are set, a soft cap of 30 is a realistic compromise. RAM (~25 pods at 256 MB) and disk (>200 pods at 300 MB) are not the bottleneck.
+- CPU is the tightest resource: at the chart's default request of 150 mCPU per pod, ~19 pods actually fit before the scheduler runs out of CPU requests. `MAX_INSTANCES=20` keeps the visible team ceiling in line with what the node can actually schedule, so no team ends up stuck on a `Pending` pod. RAM (~25 pods at 256 MB) and disk (>200 pods at 300 MB) are not the bottleneck.
 
 Guidelines for scaling up or down:
 
 - Small event (up to ~10 teams)? Drop to `SERVER_TYPE=cpx22` (2 vCPU / 4 GB, ~€6/month) with `MAX_INSTANCES=10`.
-- Want more than ~30 teams? Bump both variables together, e.g. `SERVER_TYPE=cpx42` (8 vCPU / 16 GB) with `MAX_INSTANCES=50`, or `SERVER_TYPE=cpx52` (16 vCPU / 32 GB) with `MAX_INSTANCES=100`.
+- Want more than ~20 teams? Bump both variables together, e.g. `SERVER_TYPE=cpx42` (8 vCPU / 16 GB) with `MAX_INSTANCES=40`, or `SERVER_TYPE=cpx52` (16 vCPU / 32 GB) with `MAX_INSTANCES=80`.
 - If you expect heavy concurrent traffic per team (e.g. teams actively hacking rather than reading), switch to a **dedicated-CPU** type (e.g. `ccx23` / `ccx33`) via `SERVER_TYPE` — shared-vCPU plans like `cpx*` can throttle under sustained load.
 - To hard-cap the number of teams, use `MAX_INSTANCES`. See the chart's `config.maxInstances` value in [`helm/multi-juicer/values.yaml`](../../helm/multi-juicer/values.yaml) for the full list of tunables.
 

--- a/guides/hetzner/hetzner.md
+++ b/guides/hetzner/hetzner.md
@@ -1,15 +1,13 @@
 # Example Setup with Hetzner Cloud
 
-This guide sets up a MultiJuicer cluster on a single [Hetzner Cloud](https://www.hetzner.com/cloud) server, sized for up to **20 teams**, reachable via public Internet on your own domain over **HTTPS** (Let's Encrypt).
+This guide sets up a MultiJuicer cluster on a single [Hetzner Cloud](https://www.hetzner.com/cloud) server, sized for up to **20 teams**, reachable over **HTTPS** on your own domain (Let's Encrypt). The domain stays at your existing DNS provider — you just point an `A` record at the freshly-created VM.
 
-The domain is expected to be registered/managed at **your existing DNS provider** (e.g. [Strato](https://www.strato.de), GoDaddy, Namecheap, Cloudflare, ...). This guide does **not** move your domain to Hetzner — you just point a single `A` record at the freshly-created Hetzner VM.
-
-The setup is intentionally **throw-away**: everything lives on one VM, so once your event is over you delete the server (and the few surrounding resources) and pay nothing more. Two scripts in this folder do the whole thing:
+The setup is intentionally throw-away: everything lives on one VM, so after the event you delete it and pay nothing more. Two scripts do the whole thing:
 
 - [`setup.sh`](./setup.sh) — provisions everything from scratch
 - [`teardown.sh`](./teardown.sh) — deletes every Hetzner resource created by `setup.sh`
 
-**WARNING:** The default server type used here (`cpx32`, 4 vCPU / 8 GB RAM / 80 GB SSD, Hetzner's newer AMD generation) costs **€0.0677/h** on Hetzner Cloud, capped at **€42.23/month** on the monthly plan (per Hetzner's published price sheet). Delete the resources with `teardown.sh` when you no longer need them.
+> Expected costs: The default server type (`cpx32`, 4 vCPU / 8 GB RAM / 80 GB SSD) costs ~€0.07/h on Hetzner Cloud capped at ~€42/month. Run `teardown.sh` when you no longer need it.
 
 ## What the script creates
 
@@ -19,28 +17,24 @@ The setup is intentionally **throw-away**: everything lives on one VM, so once y
 | Firewall (`multi-juicer-fw`)   | Hetzner Cloud        | Allows inbound tcp/22, tcp/80, tcp/443 (world) and tcp/6443 (k8s API, restricted to your public IP) |
 | Server (`multi-juicer`, cpx32) | Hetzner Cloud        | Single-node cluster host                                         |
 | k3s (Traefik disabled)         | on the VM            | Lightweight Kubernetes                                           |
-| ingress-nginx                  | in-cluster           | HTTP(S) entry point (matches chart default `ingressClassName`)   |
+| ingress-nginx                  | in-cluster           | HTTP(S) entry point                                              |
 | cert-manager + ClusterIssuer   | in-cluster           | Automatic Let's Encrypt certificate                              |
 | MultiJuicer Helm release       | in-cluster           | The MultiJuicer balancer (2 replicas by default) + on-demand JuiceShop instances |
-| LLM gateway secret (optional)  | in-cluster           | Holds the upstream LLM API key so the JuiceShop chatbot / AI challenges work (only created when `LLM_API_KEY` is set) |
+| LLM gateway secret (optional)  | in-cluster           | Holds the upstream LLM API key for the JuiceShop chatbot / AI challenges (only created when `LLM_API_KEY` is set) |
 
-DNS is **not** in the table on purpose: the A record for `DOMAIN` stays at your existing DNS provider and is managed by you (see [Step 2](#step-2-create-the-a-record-at-your-dns-provider)).
+The `A` record for `DOMAIN` stays at your existing DNS provider and is managed by you. `setup.sh` already applies the recommendations from [`guides/production-notes/production-notes.md`](../production-notes/production-notes.md) (secure cookie, persistent `cookieParserSecret` stored in `./.multi-juicer-hetzner/cookie-parser-secret`, 2 balancer replicas, `config.maxInstances`).
 
 ## Prerequisites
 
-1. A **domain** you control at any DNS provider — you only need to be able to add a single `A` record to it.
-2. A **Hetzner Cloud API token** with read/write access — [create one here](https://console.hetzner.cloud/) under `Security > API Tokens`.
-3. The following CLI tools installed and on your `PATH`:
-   - [`hcloud`](https://github.com/hetznercloud/cli)
-   - [`kubectl`](https://kubernetes.io/docs/tasks/tools/)
-   - [`helm`](https://helm.sh)
-   - `ssh`, `ssh-keygen`, `curl`, `jq` (present on any Linux/macOS box and via WSL / Git Bash on Windows)
+1. A domain you control at any DNS provider — you only need to add a single `A` record to it.
+2. A Hetzner Cloud API token with read/write access — [create one here](https://console.hetzner.cloud/) under `Security > API Tokens`.
+3. CLI tools on your `PATH`: [`hcloud`](https://github.com/hetznercloud/cli), [`kubectl`](https://kubernetes.io/docs/tasks/tools/), [`helm`](https://helm.sh), plus `ssh`, `ssh-keygen`, `curl`, `jq`.
 
 > Windows users: run the scripts from **WSL** or **Git Bash**. Native PowerShell will not execute `bash` scripts.
 
 ## Step 1. Configure the environment and start the setup
 
-Set at least the three required variables. Everything else has sensible defaults you can override.
+Set the three required variables. Everything else has sensible defaults you can override.
 
 ```bash
 export HCLOUD_TOKEN="<your hetzner cloud api token>"
@@ -50,41 +44,35 @@ export EMAIL="you@example.com"       # used for Let's Encrypt registration
 # Optional overrides:
 # export SERVER_TYPE=cpx32           # ~20 teams. Drop to cpx22 for tiny events, or bump to cpx42 / cpx52 (or ccx23 for dedicated CPUs) for larger ones.
 # export SERVER_LOCATION=nbg1        # nbg1 | fsn1 | hel1 | ash | hil | sin
-# export MAX_INSTANCES=20            # caps the number of JuiceShop instances
-# export REPLICAS=2                  # MultiJuicer balancer replicas (production checklist recommends >=2)
+# export MAX_INSTANCES=20            # caps the number of JuiceShop instances (raise together with SERVER_TYPE)
+# export REPLICAS=2                  # MultiJuicer balancer replicas
 # export DNS_TIMEOUT=1800            # seconds to wait for DNS to propagate
-# export ADMIN_CIDR=1.2.3.4/32       # CIDR allowed to reach the k8s API (tcp/6443).
-#                                    # Defaults to your current public IPv4 (auto-detected via api.ipify.org).
+# export ADMIN_CIDR=1.2.3.4/32       # CIDR allowed to reach the k8s API (tcp/6443); defaults to your current public IPv4.
 
 # Optional: enable the LLM gateway so the JuiceShop chatbot / AI challenges work.
-# When unset, the gateway stays off and the chatbot is not available to teams.
-# See guides/llm/llm.md for background.
-# export LLM_API_KEY="sk-..."                       # your upstream LLM API key
-# export LLM_MODEL="inclusionai/ling-3.0-flash-fin:free" # default shown
-# export LLM_API_URL="https://openrouter.ai/api/v1" # any OpenAI-compatible base URL
+# See guides/llm/llm.md for background. The gateway keeps the API key inside the cluster;
+# note there is no per-team rate limit, so set a spending cap at your provider before the event.
+# export LLM_API_KEY="sk-..."                            # your upstream LLM API key
+# export LLM_MODEL="inclusionai/ling-3.0-flash-fin:free" # any model your provider serves
+# export LLM_API_URL="https://openrouter.ai/api/v1"     # any OpenAI-compatible base URL
 
 cd guides/hetzner
 chmod +x setup.sh teardown.sh
 ./setup.sh
 ```
 
-The script first provisions the Hetzner Cloud SSH key, firewall and server, then **pauses** and prints the VM's public IPv4, e.g.:
+The script first provisions the SSH key, firewall and server, then **pauses** and prints the VM's public IPv4, e.g.:
 
 ```
-----------------------------------------------------------------------
-Create an A record at your DNS provider (e.g. Strato) before continuing:
+Create an A record at your DNS provider before continuing:
 
     Host / Name:  juicy.example.com
     Type:         A
     Value / IPv4: 203.0.113.42
     TTL:          as low as your provider allows (e.g. 300 s / 1 min)
-
-The script will now poll public DNS every 10 s until juicy.example.com
-resolves to 203.0.113.42. Press Ctrl+C to abort.
-----------------------------------------------------------------------
 ```
 
-Leave the script running and switch to your DNS provider to create the record — see the next step.
+Leave the script running while continuing with [Step 2](#step-2-create-the-a-record-at-your-dns-provider).
 
 ## Step 2. Create the A record at your DNS provider
 
@@ -95,47 +83,20 @@ You need one DNS record:
 | Type          | `A`                                      |
 | Host / Name   | the sub-part of your `DOMAIN` (see below)|
 | Value / Target| the public IPv4 printed by `setup.sh`    |
-| TTL           | as low as your provider allows (e.g. 60 or 300 seconds — keeps re-runs fast) |
+| TTL           | as low as your provider allows (e.g. 60 or 300 seconds) |
 
 The `Host` field is the part of `DOMAIN` **before** your registered domain:
 
 - `DOMAIN=juicy.example.com`, registered domain `example.com` → Host = `juicy`
 - `DOMAIN=example.com` (the apex) → Host = `@` (or leave blank, depending on the provider)
 
-### Strato (strato.de) — click-by-click
-
-Strato splits this into two screens: you first create (or select) the subdomain under the domain, then you edit its DNS **A-Record** and point it at your own IP. If you are pointing the apex domain (`DOMAIN=example.com`) at Hetzner, skip step 2 — the A-Record for the domain itself is edited directly.
-
-Log in at <https://www.strato.de/apps/CustomerService> and open your package, then:
-
-1. **Open Domain management** — go to **Domains → Domainverwaltung**. You will see all domains of your package.
-2. **Create the subdomain** (only when `DOMAIN` is a subdomain like `juicy.example.com`):
-   - In the row of the parent domain (e.g. `example.com`) click **Webserver** (or **Subdomains anzeigen → Subdomain anlegen** on older UIs).
-   - Enter the subdomain label (the `Host` from the table above, e.g. `juicy`) and click **Subdomain anlegen** (Create subdomain).
-   - Strato usually points a fresh subdomain at its shared hosting by default; the next step overrides that with your Hetzner IP.
-3. **Open the DNS settings** — back in **Domainverwaltung**, click the ⚙ **gear icon** next to the entry you want to change:
-   - For a subdomain: the gear icon of the subdomain row you just created.
-   - For the apex `DOMAIN=example.com`: the gear icon of the domain itself.
-4. **Edit the A-Record** — switch to the **DNS** tab and click **A-Record verwalten** (Manage A-Record).
-5. **Point it at Hetzner** — switch the selector from the default (Strato hosting) to **Eigene IP-Adresse** (Own IP address), enter the IPv4 printed by `setup.sh` (e.g. `203.0.113.42`) and confirm with **Einstellungen übernehmen** (Apply settings).
-
-While you are on the same **DNS** tab, also check **AAAA-Record verwalten**: if there is a stale IPv6 record from Strato's shared hosting, either delete it or point it at the server's IPv6 (`hcloud server describe multi-juicer` shows it). A stale `AAAA` can make the browser prefer IPv6 and skip the fresh `A` record, and it also breaks the Let's Encrypt HTTP-01 challenge.
-
-Strato usually publishes the change within a few minutes; the `setup.sh` polling loop will pick it up automatically. Note that Strato only exposes A-, AAAA-, MX-, TXT-, CNAME- and NS-Record editors — there is no generic "add DNS record" dialog with a free-form prefix field, so the subdomain always has to exist as its own entry before you can point it anywhere.
-
-### Other providers
-
-Any DNS provider works the same way — add one `A` record `DOMAIN → <printed IP>`. Some common admin panels:
-
-- **Cloudflare**: `example.com` zone → **DNS** → **Add record** (Type = `A`, Name = subdomain, IPv4 = printed IP; turn **Proxy status** off so Let's Encrypt sees the server directly).
-- **Namecheap**: Domain list → **Manage → Advanced DNS → Add new record** (Type = `A Record`, Host = subdomain, Value = printed IP).
-- **GoDaddy**: **My Products → DNS → Add** (Type = `A`, Name = subdomain, Value = printed IP).
+If your provider also serves a stale `AAAA` (IPv6) record for the same host, delete it or point it at the server's IPv6 (`hcloud server describe multi-juicer` shows it) — otherwise browsers may prefer IPv6 and skip the fresh `A` record, and the Let's Encrypt HTTP-01 challenge breaks.
 
 Once DNS has propagated (usually seconds to minutes for a small TTL), the script continues automatically and installs k3s, ingress-nginx, cert-manager and MultiJuicer.
 
-## Step 3. Wait for the install to finish
+## Step 3. Wait for the installation to finish
 
-Expect the full run to take about **5–8 minutes** — most of the time is spent booting the VM, pulling the k3s + ingress-nginx + cert-manager + JuiceShop images, and issuing the Let's Encrypt certificate. The script is idempotent: if you re-run it, existing Hetzner resources are reused and the DNS wait loop short-circuits as soon as the record already resolves.
+Expect the full run to take about **5–8 minutes**. The script is idempotent: if you re-run it, existing Hetzner resources are reused and the DNS wait loop short-circuits as soon as the record already resolves.
 
 When it finishes, it prints:
 
@@ -173,77 +134,4 @@ Then browse to `https://<DOMAIN>/balancer/` and log in as team `admin` with the 
 
 This deletes the Hetzner Cloud server, firewall and SSH key, and wipes the local `.multi-juicer-hetzner/` state directory. From this point on, no Hetzner resources are being billed.
 
-The `A` record at your DNS provider is **not** touched by `teardown.sh` — remove it manually at Strato / your registrar if you no longer need it (or leave it in place if you plan to spin the cluster up again for the next event; the next `setup.sh` run will just re-use it once you update it to the new VM's IP).
-
-## Production hardening baked into `setup.sh`
-
-The script already applies the recommendations from [`guides/production-notes/production-notes.md`](../production-notes/production-notes.md) so you don't have to think about them:
-
-- **`cookie.secure=true`** — the balancer session cookie is only sent over HTTPS (safe here because everything runs behind Let's Encrypt).
-- **Persistent `cookie.cookieParserSecret`** — a 24-char random secret is generated on the first run and stored in `./.multi-juicer-hetzner/cookie-parser-secret`. Re-runs reuse it, so `helm upgrade` no longer invalidates all team sessions. Delete the file if you want to force a rotation.
-- **`replicas=2`** — two balancer pods on the single node, so a pod crash or rolling upgrade does not take the whole event offline. Override with `REPLICAS=<n>`. (Note: the node itself is a single VM — for real HA you would need multiple nodes.)
-- **`config.maxInstances=20`** — matches the ~20 team sizing of the default `cpx32`. Override with `MAX_INSTANCES` (and pick a bigger `SERVER_TYPE` if you raise it much).
-
-## AI / LLM challenges
-
-Juice Shop's chatbot talks to an OpenAI-compatible LLM. MultiJuicer ships an internal **LLM gateway** so the real API key never lands inside a JuiceShop pod — see [`guides/llm/llm.md`](../llm/llm.md) for the full background.
-
-To enable it in this Hetzner setup, set `LLM_API_KEY` (and optionally `LLM_MODEL` / `LLM_API_URL`) **before** running `setup.sh`:
-
-```bash
-export LLM_API_KEY="sk-..."                       # OpenAI / OpenRouter / Ollama key
-export LLM_MODEL="inclusionai/ling-3.0-flash-fin:free" # any model your provider serves
-export LLM_API_URL="https://openrouter.ai/api/v1" # any OpenAI-compatible base URL
-./setup.sh
-```
-
-The script then creates a Kubernetes Secret `multi-juicer-llm` in the `default` namespace and passes `config.juiceShop.llm.enabled=true` (plus `model`, `apiUrl`, and `existingSecret`) to Helm. You can rotate the key later by re-exporting `LLM_API_KEY` and re-running `setup.sh` — the secret is upserted via `kubectl apply`.
-
-If `LLM_API_KEY` is **not** set, the script prints a warning and leaves the gateway off. The rest of MultiJuicer still works; only the JuiceShop chatbot / AI challenges are unavailable to teams.
-
-> **Cost tip:** the gateway does not enforce per-team rate limits — set a spending cap at your LLM provider before the event.
-
-### LLM connectivity preflight
-
-Before installing MultiJuicer, `setup.sh` runs a small probe *from the Hetzner VM itself* (via SSH) that:
-
-1. `curl`s `${LLM_API_URL}/models` with a 15 s timeout and accepts any 2xx-4xx as "network path works" (a 401 is fine here — it means the provider replied).
-2. If `LLM_API_KEY` is set, lists the provider's model catalog with a Bearer token and checks that `LLM_MODEL` is included.
-
-Both checks are **non-fatal** — the install continues either way — but they print a bright yellow warning and the final summary tags the LLM line with `(WARNING: ...)`. This is the most reliable diagnosis for the classic *"local Juice Shop chatbot works, on Hetzner it takes forever and then errors out"* symptom: the outgoing network path is fine (Hetzner Cloud firewalls only filter **inbound** traffic — outbound is unrestricted), and the culprit is almost always an upstream issue — most often a **wrong model id**. When Juice Shop asks the provider for a model that the account cannot access, the request hangs on a slow 4xx, Juice Shop retries, and eventually surfaces as a chatbot error in the UI.
-
-If you see the warning, reproduce and diagnose manually from the VM:
-
-```bash
-export KUBECONFIG="$(pwd)/.multi-juicer-hetzner/kubeconfig.yaml"
-ssh -i ./.multi-juicer-hetzner/id_ed25519 root@<IP> \
-  curl -sS -H "Authorization: Bearer $LLM_API_KEY" \
-  https://openrouter.ai/api/v1/models | jq '.data | map(.id)' | grep -i <partial-model-name>
-```
-
-Then re-run with a valid id, e.g. `LLM_MODEL="<the-id-you-just-found>" ./setup.sh` — the script is idempotent and only rewrites the LLM Helm values.
-
-## Sizing notes
-
-The defaults target a mid-sized event on a `cpx32` (4 vCPU / 8 GB RAM / 80 GB SSD, Hetzner's newer AMD generation). The math behind `MAX_INSTANCES=20`:
-
-- Per Juice Shop pod (from the upstream project's stated **minimum** system requirements): **256 MB RAM**, **200 millicpu**, **300 MB disk**. Recommended is 384 MB / 400 millicpu / 800 MB disk.
-- k3s + ingress-nginx + cert-manager + 2 MultiJuicer balancer replicas reserve roughly **1.1 vCPU** and **1.4 GB RAM** on the node, leaving about **2.9 vCPU**, **6.6 GB RAM** and ~70 GB free disk for Juice Shop pods.
-- CPU is the tightest resource: at the chart's default request of 150 mCPU per pod, ~19 pods actually fit before the scheduler runs out of CPU requests. `MAX_INSTANCES=20` keeps the visible team ceiling in line with what the node can actually schedule, so no team ends up stuck on a `Pending` pod. RAM (~25 pods at 256 MB) and disk (>200 pods at 300 MB) are not the bottleneck.
-
-Guidelines for scaling up or down:
-
-- Small event (up to ~10 teams)? Drop to `SERVER_TYPE=cpx22` (2 vCPU / 4 GB, ~€6/month) with `MAX_INSTANCES=10`.
-- Want more than ~20 teams? Bump both variables together, e.g. `SERVER_TYPE=cpx42` (8 vCPU / 16 GB) with `MAX_INSTANCES=40`, or `SERVER_TYPE=cpx52` (16 vCPU / 32 GB) with `MAX_INSTANCES=80`.
-- If you expect heavy concurrent traffic per team (e.g. teams actively hacking rather than reading), switch to a **dedicated-CPU** type (e.g. `ccx23` / `ccx33`) via `SERVER_TYPE` — shared-vCPU plans like `cpx*` can throttle under sustained load.
-- To hard-cap the number of teams, use `MAX_INSTANCES`. See the chart's `config.maxInstances` value in [`helm/multi-juicer/values.yaml`](../../helm/multi-juicer/values.yaml) for the full list of tunables.
-
-## Troubleshooting
-
-- **Script keeps polling and never continues** — the `A` record hasn't propagated yet. Double-check at your DNS provider that the record type is `A`, the host matches your `DOMAIN`, and the value matches the IP the script printed. You can also verify from another machine with `dig +short A <DOMAIN> @1.1.1.1` — the script uses the same Cloudflare resolver (`1.1.1.1`) via DNS-over-HTTPS.
-- **Wrong IP resolved / stale record** — if you re-created the VM, `DOMAIN` may still resolve to the previous IP because of TTL caching at your provider or resolver. Update the record at your provider, wait for the old TTL to expire, and re-run `setup.sh`.
-- **Certificate stuck in `Ready: False`** — check `kubectl describe certificate multi-juicer-tls` and `kubectl -n cert-manager logs deploy/cert-manager`. The most common cause is that DNS hasn't propagated to the Let's Encrypt validators yet; wait a minute and retry. A stale `AAAA` record pointing at a non-existent IPv6 host also breaks the ACME HTTP-01 challenge — delete or update it.
-- **Browser shows "Kubernetes Ingress Controller Fake Certificate"** — cert-manager hasn't finished the ACME challenge yet. Reload after ~30–60 s.
-- **Pods stuck `Pending`** — the node ran out of schedulable CPU or memory. On the default `cpx32`, CPU is the tightest resource, so this typically happens when `MAX_INSTANCES` is raised without also picking a bigger `SERVER_TYPE`. Choose a bigger `SERVER_TYPE` (e.g. `cpx42` / `cpx52` / `ccx33`) and re-run `setup.sh`.
-- **`kubectl` / `helm` time out with `dial tcp <ip>:6443: ... failed to respond`** — the Hetzner firewall is not letting your machine reach the Kubernetes API. `setup.sh` opens tcp/6443 only for the public IPv4 it detects via `api.ipify.org` when it runs, so if your public IP has changed since the last run (new network, VPN toggled, ISP-reassigned dynamic address), just re-run `setup.sh` — the firewall rules are re-applied every run and the current IP will be allowed. Behind a shared/corporate egress or on a dynamic range, set `ADMIN_CIDR` explicitly (e.g. `ADMIN_CIDR=203.0.113.0/24 ./setup.sh`).
-- **JuiceShop chatbot works locally but hangs / errors out on Hetzner** — this is almost never a firewall issue: Hetzner Cloud firewalls only filter *inbound* traffic, and `setup.sh`'s LLM preflight (see [LLM connectivity preflight](#llm-connectivity-preflight)) verifies from the VM that `${LLM_API_URL}/models` responds and that `LLM_MODEL` is actually listed by the provider. If the preflight prints a `!! ...` warning, the fix is upstream: fix `LLM_API_URL`, pick a model your account can access (see the provider dashboard), or bump a spending cap that the free tier has already exhausted, then re-run `setup.sh`.
+The `A` record at your DNS provider is **not** touched by `teardown.sh` — remove it manually at your registrar if you no longer need it.

--- a/guides/hetzner/hetzner.md
+++ b/guides/hetzner/hetzner.md
@@ -9,17 +9,31 @@ The setup is intentionally throw-away: everything lives on one VM, so after the 
 
 > Expected costs: The default server type (`cpx32`, 4 vCPU / 8 GB RAM / 80 GB SSD) costs ~€0.07/h on Hetzner Cloud capped at ~€42/month. Run `teardown.sh` when you no longer need it.
 
+## Recommended VM sizing
+
+The single-VM recommendations below are based on the bundled load tests. Keep
+larger events in separate deployments rather than increasing the VM size beyond
+these tiers.
+
+| Maximum teams | Hetzner VM | Configuration                                     |
+|--------------:|------------|---------------------------------------------------|
+|           <=5 | `cpx22`    | `SERVER_TYPE=cpx22`, `MAX_INSTANCES=5`            |
+|          <=20 | `cpx32`    | `SERVER_TYPE=cpx32`, `MAX_INSTANCES=20` (default) |
+|          <=30 | `cpx42`    | `SERVER_TYPE=cpx42`, `MAX_INSTANCES=30`           |
+
+> From 40 teams upward multi-second latencies might become the limiting factor, even on more powerful VMs such as `cpx52` and `cpx62`.
+
 ## What the script creates
 
-| Resource                       | Where                | Purpose                                                          |
-|--------------------------------|----------------------|------------------------------------------------------------------|
-| SSH key (`ed25519`)            | local + Hetzner Cloud | Login key for the fresh VM                                       |
-| Firewall (`multi-juicer-fw`)   | Hetzner Cloud        | Allows inbound tcp/22, tcp/80, tcp/443 (world) and tcp/6443 (k8s API, restricted to your public IP) |
-| Server (`multi-juicer`, cpx32) | Hetzner Cloud        | Single-node cluster host                                         |
-| k3s (with bundled Traefik)     | on the VM            | Lightweight Kubernetes + Traefik ingress controller              |
-| Traefik ACME certResolver      | in-cluster           | Traefik's built-in Let's Encrypt client (HTTP-01, persistent `acme.json`) |
-| MultiJuicer Helm release       | in-cluster           | The MultiJuicer balancer (2 replicas by default) + on-demand JuiceShop instances |
-| LLM gateway secret (optional)  | in-cluster           | Holds the upstream LLM API key for the JuiceShop chatbot / AI challenges (only created when `LLM_API_KEY` is set) |
+| Resource                       | Where                 | Purpose                                                                                                           |
+|--------------------------------|-----------------------|-------------------------------------------------------------------------------------------------------------------|
+| SSH key (`ed25519`)            | local + Hetzner Cloud | Login key for the fresh VM                                                                                        |
+| Firewall (`multi-juicer-fw`)   | Hetzner Cloud         | Allows inbound tcp/22, tcp/80, tcp/443 (world) and tcp/6443 (k8s API, restricted to your public IP)               |
+| Server (`multi-juicer`, cpx32) | Hetzner Cloud         | Single-node cluster host                                                                                          |
+| k3s (with bundled Traefik)     | on the VM             | Lightweight Kubernetes + Traefik ingress controller                                                               |
+| Traefik ACME certResolver      | in-cluster            | Traefik's built-in Let's Encrypt client (HTTP-01, persistent `acme.json`)                                         |
+| MultiJuicer Helm release       | in-cluster            | The MultiJuicer balancer (2 replicas by default) + on-demand JuiceShop instances                                  |
+| LLM gateway secret (optional)  | in-cluster            | Holds the upstream LLM API key for the JuiceShop chatbot / AI challenges (only created when `LLM_API_KEY` is set) |
 
 The `A` record for `DOMAIN` stays at your existing DNS provider and is managed by you. `setup.sh` already applies the recommendations from [`guides/production-notes/production-notes.md`](../production-notes/production-notes.md) (secure cookie, persistent `cookieParserSecret` stored in `./.multi-juicer-hetzner/cookie-parser-secret`, 2 balancer replicas, `config.maxInstances`).
 
@@ -41,9 +55,10 @@ export DOMAIN="juicy.example.com"    # any subdomain of a domain you control
 export EMAIL="you@example.com"       # used for Let's Encrypt registration
 
 # Optional overrides:
-# export SERVER_TYPE=cpx32           # ~20 teams. Drop to cpx22 for tiny events, or bump to cpx42 / cpx52 (or ccx23 for dedicated CPUs) for larger ones.
+# Recommended tiers: cpx22 / 5 teams, cpx32 / 20 teams (default), cpx42 / 30 teams.
+# export SERVER_TYPE=cpx32           # Select cpx22, cpx32, or cpx42 for the matching tier.
 # export SERVER_LOCATION=nbg1        # nbg1 | fsn1 | hel1 | ash | hil | sin
-# export MAX_INSTANCES=20            # caps the number of JuiceShop instances (raise together with SERVER_TYPE)
+# export MAX_INSTANCES=20            # Use 5, 20, or 30 with cpx22, cpx32, or cpx42.
 # export REPLICAS=2                  # MultiJuicer balancer replicas
 # export DNS_TIMEOUT=1800            # seconds to wait for DNS to propagate
 # export ADMIN_CIDR=1.2.3.4/32       # CIDR allowed to reach the k8s API (tcp/6443); defaults to your current public IPv4.
@@ -80,12 +95,12 @@ Leave the script running while continuing with [Step 2](#step-2-create-the-a-rec
 
 You need one DNS record:
 
-| Field         | Value                                    |
-|---------------|------------------------------------------|
-| Type          | `A`                                      |
-| Host / Name   | the sub-part of your `DOMAIN` (see below)|
-| Value / Target| the public IPv4 printed by `setup.sh`    |
-| TTL           | as low as your provider allows (e.g. 60 or 300 seconds) |
+| Field          | Value                                                   |
+|----------------|---------------------------------------------------------|
+| Type           | `A`                                                     |
+| Host / Name    | the sub-part of your `DOMAIN` (see below)               |
+| Value / Target | the public IPv4 printed by `setup.sh`                   |
+| TTL            | as low as your provider allows (e.g. 60 or 300 seconds) |
 
 The `Host` field is the part of `DOMAIN` **before** your registered domain:
 

--- a/guides/hetzner/hetzner.md
+++ b/guides/hetzner/hetzner.md
@@ -16,9 +16,8 @@ The setup is intentionally throw-away: everything lives on one VM, so after the 
 | SSH key (`ed25519`)            | local + Hetzner Cloud | Login key for the fresh VM                                       |
 | Firewall (`multi-juicer-fw`)   | Hetzner Cloud        | Allows inbound tcp/22, tcp/80, tcp/443 (world) and tcp/6443 (k8s API, restricted to your public IP) |
 | Server (`multi-juicer`, cpx32) | Hetzner Cloud        | Single-node cluster host                                         |
-| k3s (Traefik disabled)         | on the VM            | Lightweight Kubernetes                                           |
-| ingress-nginx                  | in-cluster           | HTTP(S) entry point                                              |
-| cert-manager + ClusterIssuer   | in-cluster           | Automatic Let's Encrypt certificate                              |
+| k3s (with bundled Traefik)     | on the VM            | Lightweight Kubernetes + Traefik ingress controller              |
+| Traefik ACME certResolver      | in-cluster           | Traefik's built-in Let's Encrypt client (HTTP-01, persistent `acme.json`) |
 | MultiJuicer Helm release       | in-cluster           | The MultiJuicer balancer (2 replicas by default) + on-demand JuiceShop instances |
 | LLM gateway secret (optional)  | in-cluster           | Holds the upstream LLM API key for the JuiceShop chatbot / AI challenges (only created when `LLM_API_KEY` is set) |
 
@@ -95,7 +94,7 @@ The `Host` field is the part of `DOMAIN` **before** your registered domain:
 
 If your provider also serves a stale `AAAA` (IPv6) record for the same host, delete it or point it at the server's IPv6 (`hcloud server describe multi-juicer` shows it) — otherwise browsers may prefer IPv6 and skip the fresh `A` record, and the Let's Encrypt HTTP-01 challenge breaks.
 
-Once DNS has propagated (usually seconds to minutes for a small TTL), the script continues automatically and installs k3s, ingress-nginx, cert-manager and MultiJuicer.
+Once DNS has propagated (usually seconds to minutes for a small TTL), the script continues automatically and installs k3s (with the bundled Traefik ingress controller + a Let's Encrypt `certResolver`) and MultiJuicer.
 
 ## Step 3. Wait for the installation to finish
 
@@ -111,7 +110,7 @@ Kubeconfig:       ./.multi-juicer-hetzner/kubeconfig.yaml
 SSH into server:  ssh -i ./.multi-juicer-hetzner/id_ed25519 root@<ip>
 ```
 
-Open `https://<DOMAIN>` in your browser. The first hit may briefly show the ingress' default self-signed certificate while cert-manager completes the HTTP-01 challenge — reload after a few seconds.
+Open `https://<DOMAIN>` in your browser. The first hit may briefly show Traefik's default self-signed certificate while Traefik completes the Let's Encrypt HTTP-01 challenge — reload after a few seconds.
 
 ## Step 4. Verify
 
@@ -121,7 +120,9 @@ export KUBECONFIG="$(pwd)/.multi-juicer-hetzner/kubeconfig.yaml"
 
 kubectl get pods -A
 kubectl get ingress
-kubectl get certificate    # should show READY=True within ~1 minute
+# Traefik stores the issued cert in acme.json on its persistent volume;
+# once the first HTTPS request has been served, the cert is cached there.
+kubectl -n kube-system logs deploy/traefik | grep -i acme    # look for successful certificate issuance
 
 # Admin password:
 kubectl get secrets multi-juicer-secret -o jsonpath='{.data.adminPassword}' | base64 -d

--- a/guides/hetzner/hetzner.md
+++ b/guides/hetzner/hetzner.md
@@ -48,6 +48,9 @@ export EMAIL="you@example.com"       # used for Let's Encrypt registration
 # export REPLICAS=2                  # MultiJuicer balancer replicas
 # export DNS_TIMEOUT=1800            # seconds to wait for DNS to propagate
 # export ADMIN_CIDR=1.2.3.4/32       # CIDR allowed to reach the k8s API (tcp/6443); defaults to your current public IPv4.
+# export ADMIN_CIDR_RESET=1          # On re-run, drop previously-allowed admin IPs instead of appending the new one.
+#                                    # Handy when travelling: re-running setup.sh from a hotel/venue *adds* your new
+#                                    # public IP to the tcp/6443 allowlist and keeps existing ones (server untouched).
 
 # Optional: enable the LLM gateway so the JuiceShop chatbot / AI challenges work.
 # See guides/llm/llm.md for background. The gateway keeps the API key inside the cluster;

--- a/guides/hetzner/hetzner.md
+++ b/guides/hetzner/hetzner.md
@@ -1,0 +1,227 @@
+# Example Setup with Hetzner Cloud
+
+This guide sets up a MultiJuicer cluster on a single [Hetzner Cloud](https://www.hetzner.com/cloud) server, sized for up to **10 teams**, reachable via public Internet on your own domain over **HTTPS** (Let's Encrypt).
+
+The domain is expected to be registered/managed at **your existing DNS provider** (e.g. [Strato](https://www.strato.de), GoDaddy, Namecheap, Cloudflare, ...). This guide does **not** move your domain to Hetzner — you just point a single `A` record at the freshly-created Hetzner VM.
+
+The setup is intentionally **throw-away**: everything lives on one VM, so once your event is over you delete the server (and the few surrounding resources) and pay nothing more. Two scripts in this folder do the whole thing:
+
+- [`setup.sh`](./setup.sh) — provisions everything from scratch
+- [`teardown.sh`](./teardown.sh) — deletes every Hetzner resource created by `setup.sh`
+
+**WARNING:** The default server type used here (`cpx22`, 2 vCPU / 4 GB RAM / 40 GB SSD) costs roughly **€6/month** (~€0.01/h) on Hetzner Cloud. Delete the resources with `teardown.sh` when you no longer need them.
+
+## What the script creates
+
+| Resource                       | Where                | Purpose                                                          |
+|--------------------------------|----------------------|------------------------------------------------------------------|
+| SSH key (`ed25519`)            | local + Hetzner Cloud | Login key for the fresh VM                                       |
+| Firewall (`multi-juicer-fw`)   | Hetzner Cloud        | Allows inbound tcp/22, tcp/80, tcp/443 (world) and tcp/6443 (k8s API, restricted to your public IP) |
+| Server (`multi-juicer`, cpx22) | Hetzner Cloud        | Single-node cluster host                                         |
+| k3s (Traefik disabled)         | on the VM            | Lightweight Kubernetes                                           |
+| ingress-nginx                  | in-cluster           | HTTP(S) entry point (matches chart default `ingressClassName`)   |
+| cert-manager + ClusterIssuer   | in-cluster           | Automatic Let's Encrypt certificate                              |
+| MultiJuicer Helm release       | in-cluster           | The MultiJuicer balancer (2 replicas by default) + on-demand JuiceShop instances |
+| LLM gateway secret (optional)  | in-cluster           | Holds the upstream LLM API key so the JuiceShop chatbot / AI challenges work (only created when `LLM_API_KEY` is set) |
+
+DNS is **not** in the table on purpose: the A record for `DOMAIN` stays at your existing DNS provider and is managed by you (see [Step 2](#step-2-create-the-a-record-at-your-dns-provider)).
+
+## Prerequisites
+
+1. A **domain** you control at any DNS provider — you only need to be able to add a single `A` record to it.
+2. A **Hetzner Cloud API token** with read/write access — [create one here](https://console.hetzner.cloud/) under `Security > API Tokens`.
+3. The following CLI tools installed and on your `PATH`:
+   - [`hcloud`](https://github.com/hetznercloud/cli)
+   - [`kubectl`](https://kubernetes.io/docs/tasks/tools/)
+   - [`helm`](https://helm.sh)
+   - `ssh`, `ssh-keygen`, `curl`, `jq` (present on any Linux/macOS box and via WSL / Git Bash on Windows)
+
+> Windows users: run the scripts from **WSL** or **Git Bash**. Native PowerShell will not execute `bash` scripts.
+
+## Step 1. Configure the environment and start the setup
+
+Set at least the three required variables. Everything else has sensible defaults you can override.
+
+```bash
+export HCLOUD_TOKEN="<your hetzner cloud api token>"
+export DOMAIN="juicy.example.com"    # any subdomain of a domain you control
+export EMAIL="you@example.com"       # used for Let's Encrypt registration
+
+# Optional overrides:
+# export SERVER_TYPE=cpx22           # ~10 teams. Use cpx31/cpx41 (or ccx23 for dedicated CPUs) for larger events.
+# export SERVER_LOCATION=nbg1        # nbg1 | fsn1 | hel1 | ash | hil | sin
+# export MAX_INSTANCES=10            # caps the number of JuiceShop instances
+# export REPLICAS=2                  # MultiJuicer balancer replicas (production checklist recommends >=2)
+# export DNS_TIMEOUT=1800            # seconds to wait for DNS to propagate
+# export ADMIN_CIDR=1.2.3.4/32       # CIDR allowed to reach the k8s API (tcp/6443).
+#                                    # Defaults to your current public IPv4 (auto-detected via api.ipify.org).
+
+# Optional: enable the LLM gateway so the JuiceShop chatbot / AI challenges work.
+# When unset, the gateway stays off and the chatbot is not available to teams.
+# See guides/llm/llm.md for background.
+# export LLM_API_KEY="sk-..."                       # your upstream LLM API key
+# export LLM_MODEL="qwen/qwen3.5-9b"                # default shown
+# export LLM_API_URL="https://openrouter.ai/api/v1" # any OpenAI-compatible base URL
+
+cd guides/hetzner
+chmod +x setup.sh teardown.sh
+./setup.sh
+```
+
+The script first provisions the Hetzner Cloud SSH key, firewall and server, then **pauses** and prints the VM's public IPv4, e.g.:
+
+```
+----------------------------------------------------------------------
+Create an A record at your DNS provider (e.g. Strato) before continuing:
+
+    Host / Name:  juicy.example.com
+    Type:         A
+    Value / IPv4: 203.0.113.42
+    TTL:          as low as your provider allows (e.g. 300 s / 1 min)
+
+The script will now poll public DNS every 10 s until juicy.example.com
+resolves to 203.0.113.42. Press Ctrl+C to abort.
+----------------------------------------------------------------------
+```
+
+Leave the script running and switch to your DNS provider to create the record — see the next step.
+
+## Step 2. Create the A record at your DNS provider
+
+You need one DNS record:
+
+| Field         | Value                                    |
+|---------------|------------------------------------------|
+| Type          | `A`                                      |
+| Host / Name   | the sub-part of your `DOMAIN` (see below)|
+| Value / Target| the public IPv4 printed by `setup.sh`    |
+| TTL           | as low as your provider allows (e.g. 60 or 300 seconds — keeps re-runs fast) |
+
+The `Host` field is the part of `DOMAIN` **before** your registered domain:
+
+- `DOMAIN=juicy.example.com`, registered domain `example.com` → Host = `juicy`
+- `DOMAIN=example.com` (the apex) → Host = `@` (or leave blank, depending on the provider)
+
+### Strato (strato.de) — click-by-click
+
+Strato splits this into two screens: you first create (or select) the subdomain under the domain, then you edit its DNS **A-Record** and point it at your own IP. If you are pointing the apex domain (`DOMAIN=example.com`) at Hetzner, skip step 2 — the A-Record for the domain itself is edited directly.
+
+Log in at <https://www.strato.de/apps/CustomerService> and open your package, then:
+
+1. **Open Domain management** — go to **Domains → Domainverwaltung**. You will see all domains of your package.
+2. **Create the subdomain** (only when `DOMAIN` is a subdomain like `juicy.example.com`):
+   - In the row of the parent domain (e.g. `example.com`) click **Webserver** (or **Subdomains anzeigen → Subdomain anlegen** on older UIs).
+   - Enter the subdomain label (the `Host` from the table above, e.g. `juicy`) and click **Subdomain anlegen** (Create subdomain).
+   - Strato usually points a fresh subdomain at its shared hosting by default; the next step overrides that with your Hetzner IP.
+3. **Open the DNS settings** — back in **Domainverwaltung**, click the ⚙ **gear icon** next to the entry you want to change:
+   - For a subdomain: the gear icon of the subdomain row you just created.
+   - For the apex `DOMAIN=example.com`: the gear icon of the domain itself.
+4. **Edit the A-Record** — switch to the **DNS** tab and click **A-Record verwalten** (Manage A-Record).
+5. **Point it at Hetzner** — switch the selector from the default (Strato hosting) to **Eigene IP-Adresse** (Own IP address), enter the IPv4 printed by `setup.sh` (e.g. `203.0.113.42`) and confirm with **Einstellungen übernehmen** (Apply settings).
+
+While you are on the same **DNS** tab, also check **AAAA-Record verwalten**: if there is a stale IPv6 record from Strato's shared hosting, either delete it or point it at the server's IPv6 (`hcloud server describe multi-juicer` shows it). A stale `AAAA` can make the browser prefer IPv6 and skip the fresh `A` record, and it also breaks the Let's Encrypt HTTP-01 challenge.
+
+Strato usually publishes the change within a few minutes; the `setup.sh` polling loop will pick it up automatically. Note that Strato only exposes A-, AAAA-, MX-, TXT-, CNAME- and NS-Record editors — there is no generic "add DNS record" dialog with a free-form prefix field, so the subdomain always has to exist as its own entry before you can point it anywhere.
+
+### Other providers
+
+Any DNS provider works the same way — add one `A` record `DOMAIN → <printed IP>`. Some common admin panels:
+
+- **Cloudflare**: `example.com` zone → **DNS** → **Add record** (Type = `A`, Name = subdomain, IPv4 = printed IP; turn **Proxy status** off so Let's Encrypt sees the server directly).
+- **Namecheap**: Domain list → **Manage → Advanced DNS → Add new record** (Type = `A Record`, Host = subdomain, Value = printed IP).
+- **GoDaddy**: **My Products → DNS → Add** (Type = `A`, Name = subdomain, Value = printed IP).
+
+Once DNS has propagated (usually seconds to minutes for a small TTL), the script continues automatically and installs k3s, ingress-nginx, cert-manager and MultiJuicer.
+
+## Step 3. Wait for the install to finish
+
+Expect the full run to take about **5–8 minutes** — most of the time is spent booting the VM, pulling the k3s + ingress-nginx + cert-manager + JuiceShop images, and issuing the Let's Encrypt certificate. The script is idempotent: if you re-run it, existing Hetzner resources are reused and the DNS wait loop short-circuits as soon as the record already resolves.
+
+When it finishes, it prints:
+
+```
+URL:              https://juicy.example.com
+Admin team:       admin
+Admin password:   <generated>
+Kubeconfig:       ./.multi-juicer-hetzner/kubeconfig.yaml
+SSH into server:  ssh -i ./.multi-juicer-hetzner/id_ed25519 root@<ip>
+```
+
+Open `https://<DOMAIN>` in your browser. The first hit may briefly show the ingress' default self-signed certificate while cert-manager completes the HTTP-01 challenge — reload after a few seconds.
+
+## Step 4. Verify
+
+```bash
+# Point kubectl at the fresh cluster:
+export KUBECONFIG="$(pwd)/.multi-juicer-hetzner/kubeconfig.yaml"
+
+kubectl get pods -A
+kubectl get ingress
+kubectl get certificate    # should show READY=True within ~1 minute
+
+# Admin password:
+kubectl get secrets multi-juicer-secret -o jsonpath='{.data.adminPassword}' | base64 -d
+```
+
+Then browse to `https://<DOMAIN>/balancer/` and log in as team `admin` with the printed password to access the admin UI.
+
+## Step 5. Tear everything down after the event
+
+```bash
+./teardown.sh
+```
+
+This deletes the Hetzner Cloud server, firewall and SSH key, and wipes the local `.multi-juicer-hetzner/` state directory. From this point on, no Hetzner resources are being billed.
+
+The `A` record at your DNS provider is **not** touched by `teardown.sh` — remove it manually at Strato / your registrar if you no longer need it (or leave it in place if you plan to spin the cluster up again for the next event; the next `setup.sh` run will just re-use it once you update it to the new VM's IP).
+
+## Production hardening baked into `setup.sh`
+
+The script already applies the recommendations from [`guides/production-notes/production-notes.md`](../production-notes/production-notes.md) so you don't have to think about them:
+
+- **`cookie.secure=true`** — the balancer session cookie is only sent over HTTPS (safe here because everything runs behind Let's Encrypt).
+- **Persistent `cookie.cookieParserSecret`** — a 24-char random secret is generated on the first run and stored in `./.multi-juicer-hetzner/cookie-parser-secret`. Re-runs reuse it, so `helm upgrade` no longer invalidates all team sessions. Delete the file if you want to force a rotation.
+- **`replicas=2`** — two balancer pods on the single node, so a pod crash or rolling upgrade does not take the whole event offline. Override with `REPLICAS=<n>`. (Note: the node itself is a single VM — for real HA you would need multiple nodes.)
+- **`config.maxInstances=10`** — matches the ~10 team sizing of the default `cpx22`. Override with `MAX_INSTANCES` (and pick a bigger `SERVER_TYPE` if you raise it much).
+
+## AI / LLM challenges
+
+Juice Shop's chatbot talks to an OpenAI-compatible LLM. MultiJuicer ships an internal **LLM gateway** so the real API key never lands inside a JuiceShop pod — see [`guides/llm/llm.md`](../llm/llm.md) for the full background.
+
+To enable it in this Hetzner setup, set `LLM_API_KEY` (and optionally `LLM_MODEL` / `LLM_API_URL`) **before** running `setup.sh`:
+
+```bash
+export LLM_API_KEY="sk-..."                       # OpenAI / OpenRouter / Ollama key
+export LLM_MODEL="qwen/qwen3.5-9b"                # any model your provider serves
+export LLM_API_URL="https://openrouter.ai/api/v1" # any OpenAI-compatible base URL
+./setup.sh
+```
+
+The script then creates a Kubernetes Secret `multi-juicer-llm` in the `default` namespace and passes `config.juiceShop.llm.enabled=true` (plus `model`, `apiUrl`, and `existingSecret`) to Helm. You can rotate the key later by re-exporting `LLM_API_KEY` and re-running `setup.sh` — the secret is upserted via `kubectl apply`.
+
+If `LLM_API_KEY` is **not** set, the script prints a warning and leaves the gateway off. The rest of MultiJuicer still works; only the JuiceShop chatbot / AI challenges are unavailable to teams.
+
+> **Cost tip:** the gateway does not enforce per-team rate limits — set a spending cap at your LLM provider before the event.
+
+## Sizing notes
+
+The defaults target a small event on the cheapest sensible Hetzner box (`cpx22`: 2 vCPU / 4 GB RAM / 40 GB SSD). The math behind `MAX_INSTANCES=10`:
+
+- Per Juice Shop pod (from the upstream project's stated **minimum** system requirements): **256 MB RAM**, **200 millicpu**, **300 MB disk**. Recommended is 384 MB / 400 millicpu / 800 MB disk.
+- k3s + ingress-nginx + cert-manager + 2 MultiJuicer balancer replicas reserve roughly **1.1 vCPU** and **1.4 GB RAM** on the node, leaving about **900 mCPU**, **2.6 GB RAM** and ~30 GB free disk for Juice Shop pods.
+- CPU is the tightest resource: 900 mCPU / 200 mCPU ≈ 4–5 pods at Juice Shop's stated minimum, or ~6 pods at the chart's default request of 150 mCPU. Since teams are mostly idle and no CPU **limits** are set, a soft cap of 10 is a realistic compromise. RAM (~10 pods at 256 MB) and disk (>90 pods at 300 MB) are not the bottleneck.
+
+Guidelines for scaling up:
+
+- Want more than ~10 teams? Bump both variables together, e.g. `SERVER_TYPE=cpx31` (4 vCPU / 8 GB) with `MAX_INSTANCES=25`, or the previous `SERVER_TYPE=cpx41` (8 vCPU / 16 GB) with `MAX_INSTANCES=50`.
+- If you expect heavy concurrent traffic per team (e.g. teams actively hacking rather than reading), switch to a **dedicated-CPU** type (e.g. `ccx23` / `ccx33`) via `SERVER_TYPE` — shared-vCPU plans like `cpx*` can throttle under sustained load.
+- To hard-cap the number of teams, use `MAX_INSTANCES`. See the chart's `config.maxInstances` value in [`helm/multi-juicer/values.yaml`](../../helm/multi-juicer/values.yaml) for the full list of tunables.
+
+## Troubleshooting
+
+- **Script keeps polling and never continues** — the `A` record hasn't propagated yet. Double-check at your DNS provider that the record type is `A`, the host matches your `DOMAIN`, and the value matches the IP the script printed. You can also verify from another machine with `dig +short A <DOMAIN> @1.1.1.1` — the script uses the same Cloudflare resolver (`1.1.1.1`) via DNS-over-HTTPS.
+- **Wrong IP resolved / stale record** — if you re-created the VM, `DOMAIN` may still resolve to the previous IP because of TTL caching at your provider or resolver. Update the record at your provider, wait for the old TTL to expire, and re-run `setup.sh`.
+- **Certificate stuck in `Ready: False`** — check `kubectl describe certificate multi-juicer-tls` and `kubectl -n cert-manager logs deploy/cert-manager`. The most common cause is that DNS hasn't propagated to the Let's Encrypt validators yet; wait a minute and retry. A stale `AAAA` record pointing at a non-existent IPv6 host also breaks the ACME HTTP-01 challenge — delete or update it.
+- **Browser shows "Kubernetes Ingress Controller Fake Certificate"** — cert-manager hasn't finished the ACME challenge yet. Reload after ~30–60 s.
+- **Pods stuck `Pending`** — the node ran out of schedulable CPU or memory. On the default `cpx22`, CPU is the tightest resource, so this typically happens when `MAX_INSTANCES` is raised without also picking a bigger `SERVER_TYPE`. Choose a bigger `SERVER_TYPE` (e.g. `cpx31` / `cpx41`) and re-run `setup.sh`.
+- **`kubectl` / `helm` time out with `dial tcp <ip>:6443: ... failed to respond`** — the Hetzner firewall is not letting your machine reach the Kubernetes API. `setup.sh` opens tcp/6443 only for the public IPv4 it detects via `api.ipify.org` when it runs, so if your public IP has changed since the last run (new network, VPN toggled, ISP-reassigned dynamic address), just re-run `setup.sh` — the firewall rules are re-applied every run and the current IP will be allowed. Behind a shared/corporate egress or on a dynamic range, set `ADMIN_CIDR` explicitly (e.g. `ADMIN_CIDR=203.0.113.0/24 ./setup.sh`).

--- a/guides/hetzner/setup.sh
+++ b/guides/hetzner/setup.sh
@@ -2,10 +2,10 @@
 #
 # Provision a fresh MultiJuicer cluster on Hetzner Cloud, sized for ~20 teams.
 #
-# The script creates a single Hetzner Cloud VM, installs k3s on it, deploys
-# ingress-nginx + cert-manager, installs MultiJuicer via Helm, and requests
-# a Let's Encrypt certificate so the balancer UI is reachable over HTTPS on
-# your own domain.
+# The script creates a single Hetzner Cloud VM, installs k3s on it (with the
+# bundled Traefik ingress controller), configures Traefik's built-in ACME
+# client to request a Let's Encrypt certificate, and installs MultiJuicer via
+# Helm so the balancer UI is reachable over HTTPS on your own domain.
 #
 # The domain is expected to be managed at *your* DNS provider (e.g. Strato,
 # GoDaddy, Namecheap, Cloudflare, ...). This script does NOT touch your DNS
@@ -234,12 +234,12 @@ done
 SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ${SSH_KEY_FILE} root@${SERVER_IP}"
 
 ############################
-# 6. Install k3s (Traefik disabled — we use ingress-nginx to match the chart's default ingressClassName)
+# 6. Install k3s (with bundled Traefik — we configure it below to also handle Let's Encrypt)
 ############################
 log "Installing k3s on the server"
 $SSH "curl -sfL https://get.k3s.io | \
       INSTALL_K3S_CHANNEL=${K3S_CHANNEL} \
-      INSTALL_K3S_EXEC='--disable=traefik --tls-san=${DOMAIN} --tls-san=${SERVER_IP} --write-kubeconfig-mode=644' \
+      INSTALL_K3S_EXEC='--tls-san=${DOMAIN} --tls-san=${SERVER_IP} --write-kubeconfig-mode=644' \
       sh -" >/dev/null
 
 log "Fetching kubeconfig to ${KUBECONFIG_FILE}"
@@ -252,55 +252,82 @@ log "Waiting for the node to become Ready"
 kubectl wait --for=condition=Ready node --all --timeout=180s
 
 ############################
-# 7. ingress-nginx
+# 7. Configure Traefik with Let's Encrypt (built-in ACME)
 ############################
-log "Installing ingress-nginx"
-helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx >/dev/null 2>&1 || true
-helm repo update >/dev/null
-helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx \
-  --namespace ingress-nginx --create-namespace \
-  --set controller.service.type=NodePort \
-  --set controller.hostPort.enabled=true \
-  --set controller.hostPort.ports.http=80 \
-  --set controller.hostPort.ports.https=443 \
-  --set controller.kind=DaemonSet \
-  --set controller.publishService.enabled=false
-
-kubectl -n ingress-nginx rollout status ds/ingress-nginx-controller --timeout=180s
-
-############################
-# 8. cert-manager + Let's Encrypt ClusterIssuer
-############################
-log "Installing cert-manager"
-helm repo add jetstack https://charts.jetstack.io >/dev/null 2>&1 || true
-helm repo update >/dev/null
-helm upgrade --install cert-manager jetstack/cert-manager \
-  --namespace cert-manager --create-namespace \
-  --set crds.enabled=true
-
-kubectl -n cert-manager rollout status deploy/cert-manager --timeout=180s
-kubectl -n cert-manager rollout status deploy/cert-manager-webhook --timeout=180s
-
-log "Creating Let's Encrypt ClusterIssuer"
+# k3s installs Traefik via helm-controller from a HelmChart CR in kube-system.
+# A HelmChartConfig with the same name/namespace layers extra values on top of
+# the bundled chart's defaults — we use it to add a persistent volume for
+# acme.json (so certs survive Traefik pod restarts) and an HTTP-01
+# certResolver named 'letsencrypt'. Individual ingresses opt in via the
+# `traefik.ingress.kubernetes.io/router.tls.certresolver` annotation (§10).
+#
+# No custom init container is needed: the Traefik chart's default
+# podSecurityContext (fsGroup=65532) makes the kubelet chown the mounted PVC
+# so the non-root Traefik process can write acme.json.
+log "Configuring Traefik with a Let's Encrypt certResolver"
 kubectl apply -f - <<EOF
-apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
 metadata:
-  name: letsencrypt
+  name: traefik
+  namespace: kube-system
 spec:
-  acme:
-    server: ${LE_SERVER}
-    email: ${EMAIL}
-    privateKeySecretRef:
-      name: letsencrypt-account-key
-    solvers:
-      - http01:
-          ingress:
-            class: nginx
+  valuesContent: |-
+    persistence:
+      enabled: true
+      name: traefik-data
+      accessMode: ReadWriteOnce
+      size: 128Mi
+      path: /data
+    certificatesResolvers:
+      letsencrypt:
+        acme:
+          email: ${EMAIL}
+          storage: /data/acme.json
+          caServer: ${LE_SERVER}
+          httpChallenge:
+            entryPoint: web
 EOF
 
+# helm-controller reconciles the HelmChartConfig by (re-)rendering the bundled
+# Traefik chart via a Helm install/upgrade Job in kube-system, which then
+# creates/updates the Traefik Deployment. On a fresh k3s install that Job may
+# not have finished yet at this point, so the Deployment doesn't exist and
+# `kubectl wait` / `rollout status` immediately fail with NotFound. Poll for
+# the Deployment to appear first — but also detect a failing helm-install Job
+# (bad valuesContent, chart schema mismatch, ...) and surface its logs
+# instead of hanging silently until the timeout.
+log "Waiting for Traefik to reconcile with the new configuration"
+TRAEFIK_READY=0
+for i in {1..60}; do
+  if kubectl -n kube-system get deploy traefik >/dev/null 2>&1; then
+    TRAEFIK_READY=1
+    break
+  fi
+  # If any helm-install-traefik* pod is CrashLoopBackOff / Error, the install
+  # is broken and no amount of waiting will help — dump its logs and bail out.
+  FAILING_POD="$(kubectl -n kube-system get pods \
+    -l 'helmcharts.helm.cattle.io/chart=traefik' \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.containerStatuses[*].state.waiting.reason}{"\n"}{end}' 2>/dev/null \
+    | awk -F'\t' '$2 ~ /CrashLoopBackOff|Error|ImagePullBackOff/ {print $1; exit}')"
+  if [[ -n "${FAILING_POD}" ]]; then
+    warn "Traefik helm-install Job is failing (pod ${FAILING_POD}). Recent logs:"
+    kubectl -n kube-system logs "${FAILING_POD}" --tail=40 >&2 || true
+    echo "Fix the HelmChartConfig above, then re-run setup.sh (it is idempotent)." >&2
+    exit 1
+  fi
+  printf '.'
+  sleep 5
+done
+if [[ "${TRAEFIK_READY}" != "1" ]]; then
+  echo "Traefik Deployment did not appear within 5 min. Inspect: kubectl -n kube-system get pods,helmchart,helmchartconfig" >&2
+  exit 1
+fi
+kubectl -n kube-system wait --for=condition=Available deploy/traefik --timeout=240s
+kubectl -n kube-system rollout status deploy/traefik --timeout=240s
+
 ############################
-# 9. Cookie parser secret (persistent across re-runs — otherwise every
+# 8. Cookie parser secret (persistent across re-runs — otherwise every
 #    `helm upgrade` rotates it and invalidates all team sessions)
 ############################
 if [[ ! -s "${COOKIE_SECRET_FILE}" ]]; then
@@ -317,7 +344,7 @@ fi
 COOKIE_PARSER_SECRET="$(cat "${COOKIE_SECRET_FILE}")"
 
 ############################
-# 10. Optional: LLM gateway secret (for AI / chatbot challenges)
+# 9. Optional: LLM gateway secret (for AI / chatbot challenges)
 ############################
 HELM_LLM_ARGS=()
 if [[ -n "${LLM_API_KEY}" ]]; then
@@ -341,7 +368,7 @@ else
 fi
 
 ############################
-# 11. MultiJuicer
+# 10. MultiJuicer
 ############################
 log "Installing MultiJuicer via Helm (replicas=${REPLICAS}, maxInstances=${MAX_INSTANCES})"
 helm upgrade --install multi-juicer \
@@ -352,8 +379,10 @@ helm upgrade --install multi-juicer \
   --set-string "cookie.cookieParserSecret=${COOKIE_PARSER_SECRET}" \
   --set "config.maxInstances=${MAX_INSTANCES}" \
   --set ingress.enabled=true \
-  --set ingress.ingressClassName=nginx \
-  --set-string 'ingress.annotations.cert-manager\.io/cluster-issuer=letsencrypt' \
+  --set ingress.ingressClassName=traefik \
+  --set-string 'ingress.annotations.traefik\.ingress\.kubernetes\.io/router\.tls=true' \
+  --set-string 'ingress.annotations.traefik\.ingress\.kubernetes\.io/router\.tls\.certresolver=letsencrypt' \
+  --set-string 'ingress.annotations.traefik\.ingress\.kubernetes\.io/router\.entrypoints=websecure' \
   --set "ingress.hosts[0].host=${DOMAIN}" \
   --set "ingress.hosts[0].paths[0]=/" \
   --set "ingress.tls[0].secretName=multi-juicer-tls" \
@@ -363,7 +392,7 @@ helm upgrade --install multi-juicer \
 kubectl -n default rollout status deploy/multi-juicer --timeout=180s
 
 ############################
-# 12. Done
+# 11. Done
 ############################
 ADMIN_PW="$(kubectl get secret multi-juicer-secret -o jsonpath='{.data.adminPassword}' | base64 -d)"
 
@@ -387,9 +416,9 @@ $(log "MultiJuicer is ready")
   SSH into server:  ssh -i ${SSH_KEY_FILE} root@${SERVER_IP}
   Cookie secret:    ${COOKIE_SECRET_FILE} (keep it — re-runs reuse it so team sessions survive helm upgrades)
 
-The Let's Encrypt certificate is issued on the first HTTPS request and can
-take up to a minute. If the browser initially shows the ingress default
-certificate, wait a moment and reload.
+The Let's Encrypt certificate is issued by Traefik on the first HTTPS request
+and can take up to a minute. If the browser initially shows Traefik's default
+self-signed certificate, wait a moment and reload.
 
 When your event is over, run ./teardown.sh to delete every Hetzner
 resource (server, firewall, SSH key) created by this script. The A

--- a/guides/hetzner/setup.sh
+++ b/guides/hetzner/setup.sh
@@ -118,7 +118,29 @@ if [[ -z "${ADMIN_CIDR}" ]]; then
   fi
   ADMIN_CIDR="${MY_IP}/32"
 fi
-log "Restricting Kubernetes API (tcp/6443) to ${ADMIN_CIDR}"
+
+if ! hcloud firewall describe "${FIREWALL_NAME}" >/dev/null 2>&1; then
+  log "Creating firewall '${FIREWALL_NAME}'"
+  hcloud firewall create --name "${FIREWALL_NAME}" >/dev/null
+fi
+
+# Merge the (possibly new) ADMIN_CIDR into the firewall's existing 6443 allowlist
+# instead of replacing it. This lets you re-run setup.sh from a new location
+# (different public IP — e.g. home vs. hotel/venue) and *add* your current IP
+# while keeping the previously-allowed ones. Set ADMIN_CIDR_RESET=1 to instead
+# drop all previous entries and keep only the current ADMIN_CIDR.
+ADMIN_CIDR_RESET="${ADMIN_CIDR_RESET:-0}"
+EXISTING_ADMIN_CIDRS=""
+if [[ "${ADMIN_CIDR_RESET}" != "1" ]]; then
+  EXISTING_ADMIN_CIDRS="$(hcloud firewall describe "${FIREWALL_NAME}" -o json 2>/dev/null \
+    | jq -r '(.rules // []) | map(select(.direction=="in" and .protocol=="tcp" and .port=="6443")) | .[].source_ips[]?' \
+    || true)"
+fi
+ADMIN_CIDRS_JSON="$(printf '%s\n%s\n' "${EXISTING_ADMIN_CIDRS}" "${ADMIN_CIDR}" \
+  | awk 'NF && !seen[$0]++' \
+  | jq -R . | jq -s .)"
+
+log "Allowing Kubernetes API (tcp/6443) from: $(echo "${ADMIN_CIDRS_JSON}" | jq -r 'join(", ")')"
 
 RULES_FILE="${STATE_DIR}/firewall-rules.json"
 cat > "${RULES_FILE}" <<EOF
@@ -126,14 +148,10 @@ cat > "${RULES_FILE}" <<EOF
   {"direction":"in","protocol":"tcp","port":"22",  "source_ips":["0.0.0.0/0","::/0"]},
   {"direction":"in","protocol":"tcp","port":"80",  "source_ips":["0.0.0.0/0","::/0"]},
   {"direction":"in","protocol":"tcp","port":"443", "source_ips":["0.0.0.0/0","::/0"]},
-  {"direction":"in","protocol":"tcp","port":"6443","source_ips":["${ADMIN_CIDR}"]}
+  {"direction":"in","protocol":"tcp","port":"6443","source_ips":${ADMIN_CIDRS_JSON}}
 ]
 EOF
 
-if ! hcloud firewall describe "${FIREWALL_NAME}" >/dev/null 2>&1; then
-  log "Creating firewall '${FIREWALL_NAME}'"
-  hcloud firewall create --name "${FIREWALL_NAME}" >/dev/null
-fi
 log "Applying firewall rules to '${FIREWALL_NAME}'"
 hcloud firewall replace-rules "${FIREWALL_NAME}" --rules-file "${RULES_FILE}" >/dev/null
 

--- a/guides/hetzner/setup.sh
+++ b/guides/hetzner/setup.sh
@@ -1,0 +1,383 @@
+#!/usr/bin/env bash
+#
+# Provision a fresh MultiJuicer cluster on Hetzner Cloud, sized for ~10 teams.
+#
+# The script creates a single Hetzner Cloud VM, installs k3s on it, deploys
+# ingress-nginx + cert-manager, installs MultiJuicer via Helm, and requests
+# a Let's Encrypt certificate so the balancer UI is reachable over HTTPS on
+# your own domain.
+#
+# The domain is expected to be managed at *your* DNS provider (e.g. Strato,
+# GoDaddy, Namecheap, Cloudflare, ...). This script does NOT touch your DNS
+# zone. After creating the VM, it prints the VM's public IPv4 and then
+# waits until your domain's A record resolves to that IP before continuing
+# with the k3s / ingress / Let's Encrypt part. See hetzner.md for how to
+# create the A record at Strato.
+#
+# The setup is intentionally "throw-away": run this before your event,
+# run `teardown.sh` afterwards, and every Hetzner resource created here
+# is gone.
+#
+# Prerequisites (see hetzner.md):
+#   - hcloud  (https://github.com/hetznercloud/cli)
+#   - kubectl (https://kubernetes.io/docs/tasks/tools/)
+#   - helm    (https://helm.sh)
+#   - ssh, ssh-keygen, curl, jq
+#   - A Hetzner Cloud API token   -> env HCLOUD_TOKEN
+#   - A domain you control        -> env DOMAIN   (e.g. juicy.example.com)
+#     (the A record for it will be   env EMAIL    (used for Let's Encrypt)
+#      created manually at your
+#      registrar, e.g. Strato)
+#
+# Optional (for AI / LLM challenges — see guides/llm/llm.md):
+#   - env LLM_API_KEY   API key of an OpenAI-compatible LLM provider.
+#                       When set, MultiJuicer's built-in LLM gateway is enabled
+#                       so the JuiceShop chatbot works for all teams while the
+#                       real API key stays inside the cluster.
+#   - env LLM_MODEL     Model identifier to expose to JuiceShop
+#                       (default: qwen/qwen3.5-9b).
+#   - env LLM_API_URL   Upstream base URL, including path prefix
+#                       (default: https://openrouter.ai/api/v1).
+
+set -euo pipefail
+
+############################
+# Configuration (override via env vars)
+############################
+: "${HCLOUD_TOKEN:?HCLOUD_TOKEN is required (Hetzner Cloud API token)}"
+: "${DOMAIN:?DOMAIN is required, e.g. juicy.example.com (managed at your DNS provider)}"
+: "${EMAIL:?EMAIL is required (used for Lets Encrypt registration)}"
+
+# Production-hardening defaults (see guides/production-notes/production-notes.md).
+REPLICAS="${REPLICAS:-2}"                           # >=2 balancer replicas for pod-crash / upgrade resilience
+
+# Optional LLM gateway (see guides/llm/llm.md). Only enabled when LLM_API_KEY is set.
+LLM_API_KEY="${LLM_API_KEY:-}"
+LLM_MODEL="${LLM_MODEL:-qwen/qwen3.5-9b}"
+LLM_API_URL="${LLM_API_URL:-https://openrouter.ai/api/v1}"
+LLM_SECRET_NAME="${LLM_SECRET_NAME:-multi-juicer-llm}"
+
+# Server / cluster sizing. cpx22 = 2 vCPU / 4 GB RAM / 40 GB SSD.
+# CPU is the tightest resource — see the sizing notes in hetzner.md for the math.
+# Bump to cpx31 / cpx41 (and raise MAX_INSTANCES accordingly) for larger events.
+SERVER_NAME="${SERVER_NAME:-multi-juicer}"
+SERVER_TYPE="${SERVER_TYPE:-cpx22}"
+SERVER_IMAGE="${SERVER_IMAGE:-ubuntu-24.04}"
+SERVER_LOCATION="${SERVER_LOCATION:-nbg1}"          # Nuremberg
+SSH_KEY_NAME="${SSH_KEY_NAME:-${SERVER_NAME}-key}"
+FIREWALL_NAME="${FIREWALL_NAME:-${SERVER_NAME}-fw}"
+K3S_CHANNEL="${K3S_CHANNEL:-stable}"
+MAX_INSTANCES="${MAX_INSTANCES:-10}"                # allowed team count (fits a cpx22; raise together with SERVER_TYPE)
+LE_SERVER="${LE_SERVER:-https://acme-v02.api.letsencrypt.org/directory}"
+STATE_DIR="${STATE_DIR:-$(pwd)/.multi-juicer-hetzner}"
+KUBECONFIG_FILE="${STATE_DIR}/kubeconfig.yaml"
+SSH_KEY_FILE="${STATE_DIR}/id_ed25519"
+COOKIE_SECRET_FILE="${COOKIE_SECRET_FILE:-${STATE_DIR}/cookie-parser-secret}"
+
+export HCLOUD_TOKEN
+export KUBECONFIG="${KUBECONFIG_FILE}"
+
+mkdir -p "${STATE_DIR}"
+chmod 700 "${STATE_DIR}"
+
+log()  { printf '\n\033[1;32m==> %s\033[0m\n' "$*"; }
+warn() { printf '\n\033[1;33m!!  %s\033[0m\n' "$*" >&2; }
+
+############################
+# 0. Sanity checks
+############################
+for bin in hcloud kubectl helm ssh ssh-keygen curl jq; do
+  command -v "$bin" >/dev/null 2>&1 || { echo "Missing required binary: $bin" >&2; exit 1; }
+done
+
+############################
+# 1. SSH key
+############################
+if [[ ! -f "${SSH_KEY_FILE}" ]]; then
+  log "Generating ephemeral SSH key at ${SSH_KEY_FILE}"
+  ssh-keygen -t ed25519 -N '' -C "${SERVER_NAME}" -f "${SSH_KEY_FILE}" >/dev/null
+fi
+
+if ! hcloud ssh-key describe "${SSH_KEY_NAME}" >/dev/null 2>&1; then
+  log "Uploading SSH key '${SSH_KEY_NAME}' to Hetzner Cloud"
+  hcloud ssh-key create --name "${SSH_KEY_NAME}" --public-key-from-file "${SSH_KEY_FILE}.pub" >/dev/null
+fi
+
+############################
+# 2. Firewall (22 SSH, 80/443 HTTP(S), 6443 k8s API restricted to your IP)
+############################
+# The k3s API server listens on tcp/6443. kubectl / helm on your machine
+# need to reach it, so we open that port on the Hetzner firewall — but only
+# for *your* current public IP (a /32) so the API is not world-exposed.
+# Override ADMIN_CIDR (e.g. `1.2.3.0/24`) if you are behind a shared/dynamic
+# egress or want to allow a company range.
+ADMIN_CIDR="${ADMIN_CIDR:-}"
+if [[ -z "${ADMIN_CIDR}" ]]; then
+  MY_IP="$(curl -sS https://api.ipify.org 2>/dev/null || true)"
+  if [[ -z "${MY_IP}" ]]; then
+    echo "Could not auto-detect your public IPv4 (api.ipify.org unreachable). Set ADMIN_CIDR=<ip>/32 explicitly." >&2
+    exit 1
+  fi
+  ADMIN_CIDR="${MY_IP}/32"
+fi
+log "Restricting Kubernetes API (tcp/6443) to ${ADMIN_CIDR}"
+
+RULES_FILE="${STATE_DIR}/firewall-rules.json"
+cat > "${RULES_FILE}" <<EOF
+[
+  {"direction":"in","protocol":"tcp","port":"22",  "source_ips":["0.0.0.0/0","::/0"]},
+  {"direction":"in","protocol":"tcp","port":"80",  "source_ips":["0.0.0.0/0","::/0"]},
+  {"direction":"in","protocol":"tcp","port":"443", "source_ips":["0.0.0.0/0","::/0"]},
+  {"direction":"in","protocol":"tcp","port":"6443","source_ips":["${ADMIN_CIDR}"]}
+]
+EOF
+
+if ! hcloud firewall describe "${FIREWALL_NAME}" >/dev/null 2>&1; then
+  log "Creating firewall '${FIREWALL_NAME}'"
+  hcloud firewall create --name "${FIREWALL_NAME}" >/dev/null
+fi
+log "Applying firewall rules to '${FIREWALL_NAME}'"
+hcloud firewall replace-rules "${FIREWALL_NAME}" --rules-file "${RULES_FILE}" >/dev/null
+
+############################
+# 3. Server
+############################
+if ! hcloud server describe "${SERVER_NAME}" >/dev/null 2>&1; then
+  log "Creating server '${SERVER_NAME}' (${SERVER_TYPE}, ${SERVER_LOCATION}, ${SERVER_IMAGE})"
+  hcloud server create \
+    --name       "${SERVER_NAME}" \
+    --type       "${SERVER_TYPE}" \
+    --image      "${SERVER_IMAGE}" \
+    --location   "${SERVER_LOCATION}" \
+    --ssh-key    "${SSH_KEY_NAME}" \
+    --firewall   "${FIREWALL_NAME}" \
+    --start-after-create >/dev/null
+else
+  log "Server '${SERVER_NAME}' already exists, reusing it"
+fi
+
+SERVER_IP="$(hcloud server ip "${SERVER_NAME}")"
+log "Server public IPv4: ${SERVER_IP}"
+
+############################
+# 4. Wait until the user's DNS A record points to this VM
+############################
+# Uses Cloudflare's DNS-over-HTTPS (1.1.1.1) resolver so we bypass any local
+# DNS caches. curl + jq are already required by the script.
+dns_lookup_a() {
+  curl -sS -H 'accept: application/dns-json' \
+    "https://cloudflare-dns.com/dns-query?name=${DOMAIN}&type=A" \
+    | jq -r '.Answer // [] | map(select(.type==1)) | .[].data' 2>/dev/null
+}
+
+cat <<EOF
+
+----------------------------------------------------------------------
+Create an A record at your DNS provider (e.g. Strato) before continuing:
+
+    Host / Name:  ${DOMAIN}
+    Type:         A
+    Value / IPv4: ${SERVER_IP}
+    TTL:          as low as your provider allows (e.g. 300 s / 1 min)
+
+See hetzner.md for step-by-step instructions for Strato.
+The script will now poll public DNS every 10 s until ${DOMAIN}
+resolves to ${SERVER_IP}. Press Ctrl+C to abort.
+----------------------------------------------------------------------
+EOF
+
+DNS_TIMEOUT="${DNS_TIMEOUT:-1800}"   # 30 minutes
+SECONDS=0
+while :; do
+  CURRENT_IPS="$(dns_lookup_a || true)"
+  if echo "${CURRENT_IPS}" | grep -qx "${SERVER_IP}"; then
+    log "DNS OK: ${DOMAIN} -> ${SERVER_IP}"
+    break
+  fi
+  if (( SECONDS >= DNS_TIMEOUT )); then
+    echo "DNS did not propagate within ${DNS_TIMEOUT}s. ${DOMAIN} currently resolves to: ${CURRENT_IPS:-<nothing>}" >&2
+    echo "Re-run this script once the A record is in place — it is idempotent." >&2
+    exit 1
+  fi
+  printf '.'
+  sleep 10
+done
+
+############################
+# 5. Wait for SSH to be ready
+############################
+log "Waiting for SSH on ${SERVER_IP}"
+for i in {1..60}; do
+  if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+         -o ConnectTimeout=5 -i "${SSH_KEY_FILE}" \
+         "root@${SERVER_IP}" 'true' 2>/dev/null; then
+    break
+  fi
+  sleep 5
+done
+
+SSH="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ${SSH_KEY_FILE} root@${SERVER_IP}"
+
+############################
+# 6. Install k3s (Traefik disabled — we use ingress-nginx to match the chart's default ingressClassName)
+############################
+log "Installing k3s on the server"
+$SSH "curl -sfL https://get.k3s.io | \
+      INSTALL_K3S_CHANNEL=${K3S_CHANNEL} \
+      INSTALL_K3S_EXEC='--disable=traefik --tls-san=${DOMAIN} --tls-san=${SERVER_IP} --write-kubeconfig-mode=644' \
+      sh -" >/dev/null
+
+log "Fetching kubeconfig to ${KUBECONFIG_FILE}"
+$SSH 'cat /etc/rancher/k3s/k3s.yaml' \
+  | sed "s#https://127.0.0.1:6443#https://${SERVER_IP}:6443#" \
+  > "${KUBECONFIG_FILE}"
+chmod 600 "${KUBECONFIG_FILE}"
+
+log "Waiting for the node to become Ready"
+kubectl wait --for=condition=Ready node --all --timeout=180s
+
+############################
+# 7. ingress-nginx
+############################
+log "Installing ingress-nginx"
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx >/dev/null 2>&1 || true
+helm repo update >/dev/null
+helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx \
+  --namespace ingress-nginx --create-namespace \
+  --set controller.service.type=NodePort \
+  --set controller.hostPort.enabled=true \
+  --set controller.hostPort.ports.http=80 \
+  --set controller.hostPort.ports.https=443 \
+  --set controller.kind=DaemonSet \
+  --set controller.publishService.enabled=false
+
+kubectl -n ingress-nginx rollout status ds/ingress-nginx-controller --timeout=180s
+
+############################
+# 8. cert-manager + Let's Encrypt ClusterIssuer
+############################
+log "Installing cert-manager"
+helm repo add jetstack https://charts.jetstack.io >/dev/null 2>&1 || true
+helm repo update >/dev/null
+helm upgrade --install cert-manager jetstack/cert-manager \
+  --namespace cert-manager --create-namespace \
+  --set crds.enabled=true
+
+kubectl -n cert-manager rollout status deploy/cert-manager --timeout=180s
+kubectl -n cert-manager rollout status deploy/cert-manager-webhook --timeout=180s
+
+log "Creating Let's Encrypt ClusterIssuer"
+kubectl apply -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt
+spec:
+  acme:
+    server: ${LE_SERVER}
+    email: ${EMAIL}
+    privateKeySecretRef:
+      name: letsencrypt-account-key
+    solvers:
+      - http01:
+          ingress:
+            class: nginx
+EOF
+
+############################
+# 9. Cookie parser secret (persistent across re-runs — otherwise every
+#    `helm upgrade` rotates it and invalidates all team sessions)
+############################
+if [[ ! -s "${COOKIE_SECRET_FILE}" ]]; then
+  log "Generating persistent cookieParserSecret at ${COOKIE_SECRET_FILE}"
+  # 24 alphanumeric chars, matches the recommendation in production-notes.md.
+  # `head -c 24` closes the pipe early, which sends SIGPIPE to `tr` (exit 141);
+  # under `set -o pipefail` that fails the whole pipeline and aborts the script,
+  # so temporarily disable pipefail just for this one pipeline.
+  set +o pipefail
+  LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 24 > "${COOKIE_SECRET_FILE}"
+  set -o pipefail
+  chmod 600 "${COOKIE_SECRET_FILE}"
+fi
+COOKIE_PARSER_SECRET="$(cat "${COOKIE_SECRET_FILE}")"
+
+############################
+# 10. Optional: LLM gateway secret (for AI / chatbot challenges)
+############################
+HELM_LLM_ARGS=()
+if [[ -n "${LLM_API_KEY}" ]]; then
+  log "Configuring LLM gateway (model=${LLM_MODEL}, apiUrl=${LLM_API_URL})"
+  # Upsert the k8s secret with the upstream API key. `kubectl apply` avoids
+  # errors on re-runs and lets the user rotate the key by re-running setup.sh.
+  kubectl create secret generic "${LLM_SECRET_NAME}" \
+    --namespace default \
+    --from-literal=token="${LLM_API_KEY}" \
+    --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+  HELM_LLM_ARGS+=(
+    --set config.juiceShop.llm.enabled=true
+    --set-string "config.juiceShop.llm.model=${LLM_MODEL}"
+    --set-string "config.juiceShop.llm.apiUrl=${LLM_API_URL}"
+    --set-string "config.juiceShop.llm.existingSecret.name=${LLM_SECRET_NAME}"
+    --set-string config.juiceShop.llm.existingSecret.key=token
+  )
+else
+  warn "LLM_API_KEY not set — LLM gateway disabled. The JuiceShop chatbot / AI challenges will not work."
+  warn "To enable them, set LLM_API_KEY (and optionally LLM_MODEL / LLM_API_URL) and re-run setup.sh."
+fi
+
+############################
+# 11. MultiJuicer
+############################
+log "Installing MultiJuicer via Helm (replicas=${REPLICAS}, maxInstances=${MAX_INSTANCES})"
+helm upgrade --install multi-juicer \
+  oci://ghcr.io/juice-shop/multi-juicer/helm/multi-juicer \
+  --namespace default \
+  --set "replicas=${REPLICAS}" \
+  --set cookie.secure=true \
+  --set-string "cookie.cookieParserSecret=${COOKIE_PARSER_SECRET}" \
+  --set "config.maxInstances=${MAX_INSTANCES}" \
+  --set ingress.enabled=true \
+  --set ingress.ingressClassName=nginx \
+  --set-string 'ingress.annotations.cert-manager\.io/cluster-issuer=letsencrypt' \
+  --set "ingress.hosts[0].host=${DOMAIN}" \
+  --set "ingress.hosts[0].paths[0]=/" \
+  --set "ingress.tls[0].secretName=multi-juicer-tls" \
+  --set "ingress.tls[0].hosts[0]=${DOMAIN}" \
+  ${HELM_LLM_ARGS[@]+"${HELM_LLM_ARGS[@]}"}
+
+kubectl -n default rollout status deploy/multi-juicer --timeout=180s
+
+############################
+# 12. Done
+############################
+ADMIN_PW="$(kubectl get secret multi-juicer-secret -o jsonpath='{.data.adminPassword}' | base64 -d)"
+
+LLM_STATUS="disabled (JuiceShop chatbot / AI challenges will not work)"
+if [[ -n "${LLM_API_KEY}" ]]; then
+  LLM_STATUS="enabled — model=${LLM_MODEL}, upstream=${LLM_API_URL}"
+fi
+
+cat <<EOF
+
+$(log "MultiJuicer is ready")
+
+  URL:              https://${DOMAIN}
+  Admin team:       admin
+  Admin password:   ${ADMIN_PW}
+  Max teams:        ${MAX_INSTANCES}
+  Balancer replicas:${REPLICAS}
+  LLM gateway:      ${LLM_STATUS}
+
+  Kubeconfig:       ${KUBECONFIG_FILE}
+  SSH into server:  ssh -i ${SSH_KEY_FILE} root@${SERVER_IP}
+  Cookie secret:    ${COOKIE_SECRET_FILE} (keep it — re-runs reuse it so team sessions survive helm upgrades)
+
+The Let's Encrypt certificate is issued on the first HTTPS request and can
+take up to a minute. If the browser initially shows the ingress default
+certificate, wait a moment and reload.
+
+When your event is over, run ./teardown.sh to delete every Hetzner
+resource (server, firewall, SSH key) created by this script. The A
+record for ${DOMAIN} at your DNS provider is *not* touched — remove
+it there manually if you no longer need it.
+EOF

--- a/guides/hetzner/setup.sh
+++ b/guides/hetzner/setup.sh
@@ -11,8 +11,7 @@
 # GoDaddy, Namecheap, Cloudflare, ...). This script does NOT touch your DNS
 # zone. After creating the VM, it prints the VM's public IPv4 and then
 # waits until your domain's A record resolves to that IP before continuing
-# with the k3s / ingress / Let's Encrypt part. See hetzner.md for how to
-# create the A record at Strato.
+# with the k3s / ingress / Let's Encrypt part.
 #
 # The setup is intentionally "throw-away": run this before your event,
 # run `teardown.sh` afterwards, and every Hetzner resource created here
@@ -58,7 +57,6 @@ LLM_API_URL="${LLM_API_URL:-https://openrouter.ai/api/v1}"
 LLM_SECRET_NAME="${LLM_SECRET_NAME:-multi-juicer-llm}"
 
 # Server / cluster sizing. cpx32 = 4 vCPU / 8 GB RAM / 80 GB SSD (Hetzner's newer AMD generation).
-# CPU is the tightest resource — see the sizing notes in hetzner.md for the math.
 # Drop to cpx22 for tiny events, or bump to cpx42 / cpx52 (and raise MAX_INSTANCES accordingly) for larger ones.
 SERVER_NAME="${SERVER_NAME:-multi-juicer}"
 SERVER_TYPE="${SERVER_TYPE:-cpx32}"
@@ -180,7 +178,6 @@ Create an A record at your DNS provider (e.g. Strato) before continuing:
     Value / IPv4: ${SERVER_IP}
     TTL:          as low as your provider allows (e.g. 300 s / 1 min)
 
-See hetzner.md for step-by-step instructions for Strato.
 The script will now poll public DNS every 10 s until ${DOMAIN}
 resolves to ${SERVER_IP}. Press Ctrl+C to abort.
 ----------------------------------------------------------------------
@@ -304,59 +301,6 @@ COOKIE_PARSER_SECRET="$(cat "${COOKIE_SECRET_FILE}")"
 ############################
 # 10. Optional: LLM gateway secret (for AI / chatbot challenges)
 ############################
-# Preflight: verify the Hetzner VM (and therefore the in-cluster LLM gateway,
-# which egresses through the same host via k3s SNAT/MASQUERADE) can actually
-# reach the LLM provider. Hetzner Cloud firewalls only filter *inbound*
-# traffic by default, so this is a smoke test aimed at catching provider-side
-# issues (geoblocking, rate limits, DNS, wrong URL) or a locked-down network
-# on custom images. Failures here are warnings, never fatal — the rest of
-# the MultiJuicer install is unaffected.
-#
-# When LLM_API_KEY is set we additionally list the provider's model catalog
-# and warn if LLM_MODEL is not in it (common cause of "AI challenges hang
-# then time out" — the request is accepted but the upstream 4xx's on the
-# missing model, and JuiceShop retries until it gives up).
-LLM_BASE="${LLM_API_URL%/}"
-LLM_HOST="$(printf '%s' "${LLM_API_URL}" | awk -F/ '{print $3}')"
-LLM_REACHABLE=0
-LLM_MODEL_OK=0
-log "Checking outbound connectivity from the Hetzner VM to ${LLM_HOST} (${LLM_BASE}/models)"
-# `-m 15`: 15 s wall-clock ceiling. `-o /dev/null -w '%{http_code}'` prints
-# just the HTTP status (or `000` on connect/timeout failure). We accept
-# anything 2xx-4xx as "network path works" — auth/model issues are handled
-# by the follow-up check below.
-LLM_CODE="$($SSH "curl -sS -o /dev/null -m 15 -w '%{http_code}' '${LLM_BASE}/models' 2>/dev/null || true" </dev/null || true)"
-case "${LLM_CODE}" in
-  2*|3*|4*)
-    log "LLM API reachable from the Hetzner VM (HTTP ${LLM_CODE})"
-    LLM_REACHABLE=1
-    ;;
-  *)
-    warn "LLM API ${LLM_BASE}/models is NOT reachable from the Hetzner VM (curl result: '${LLM_CODE:-<no response>}')."
-    warn "Hetzner Cloud allows all outbound traffic by default, so this is almost always an upstream issue"
-    warn "(provider outage, DNS, geoblock, or wrong LLM_API_URL). Continuing anyway — the JuiceShop chatbot"
-    warn "and AI challenges will fail until you fix the upstream. You can test manually with:"
-    warn "  ssh -i ${SSH_KEY_FILE} root@${SERVER_IP} \"curl -v ${LLM_BASE}/models\""
-    ;;
-esac
-
-if [[ -n "${LLM_API_KEY}" && "${LLM_REACHABLE}" -eq 1 ]]; then
-  log "Checking model '${LLM_MODEL}' is served by ${LLM_HOST}"
-  # Passes the key via env to avoid it landing in the remote shell history or
-  # `ps` output on the VM.
-  LLM_MODELS_JSON="$($SSH "LLM_API_KEY='${LLM_API_KEY}' curl -sS -m 20 -H 'Authorization: Bearer '\"\$LLM_API_KEY\" '${LLM_BASE}/models' 2>/dev/null || true" </dev/null || true)"
-  if printf '%s' "${LLM_MODELS_JSON}" | jq -e --arg m "${LLM_MODEL}" '(.data // .models // []) | map(.id // .name) | index($m)' >/dev/null 2>&1; then
-    log "Model '${LLM_MODEL}' is available"
-    LLM_MODEL_OK=1
-  else
-    warn "Model '${LLM_MODEL}' was NOT returned by ${LLM_BASE}/models."
-    warn "Either the model id is wrong or your account cannot access it — JuiceShop AI challenges"
-    warn "will hang and eventually error out on the first chatbot request. Pick another model"
-    warn "(see your provider dashboard, e.g. https://openrouter.ai/models) and re-run with:"
-    warn "  LLM_MODEL='<other-model>' ./setup.sh"
-  fi
-fi
-
 HELM_LLM_ARGS=()
 if [[ -n "${LLM_API_KEY}" ]]; then
   log "Configuring LLM gateway (model=${LLM_MODEL}, apiUrl=${LLM_API_URL})"
@@ -408,11 +352,6 @@ ADMIN_PW="$(kubectl get secret multi-juicer-secret -o jsonpath='{.data.adminPass
 LLM_STATUS="disabled (JuiceShop chatbot / AI challenges will not work)"
 if [[ -n "${LLM_API_KEY}" ]]; then
   LLM_STATUS="enabled — model=${LLM_MODEL}, upstream=${LLM_API_URL}"
-  if [[ "${LLM_REACHABLE}" -ne 1 ]]; then
-    LLM_STATUS="${LLM_STATUS} (WARNING: upstream not reachable from the VM — see warnings above)"
-  elif [[ "${LLM_MODEL_OK}" -ne 1 ]]; then
-    LLM_STATUS="${LLM_STATUS} (WARNING: model not listed by provider — see warnings above)"
-  fi
 fi
 
 cat <<EOF

--- a/guides/hetzner/setup.sh
+++ b/guides/hetzner/setup.sh
@@ -171,7 +171,7 @@ dns_lookup_a() {
 cat <<EOF
 
 ----------------------------------------------------------------------
-Create an A record at your DNS provider (e.g. Strato) before continuing:
+Create an A record at your DNS provider before continuing:
 
     Host / Name:  ${DOMAIN}
     Type:         A

--- a/guides/hetzner/setup.sh
+++ b/guides/hetzner/setup.sh
@@ -27,15 +27,14 @@ LLM_MODEL="${LLM_MODEL:-inclusionai/ling-3.0-flash-fin:free}"
 LLM_API_URL="${LLM_API_URL:-https://openrouter.ai/api/v1}"
 LLM_SECRET_NAME="${LLM_SECRET_NAME:-multi-juicer-llm}"
 
-# cpx32 = 4 vCPU / 8 GB RAM / 80 GB SSD. Bump SERVER_TYPE + MAX_INSTANCES for larger events.
 SERVER_NAME="${SERVER_NAME:-multi-juicer}"
-SERVER_TYPE="${SERVER_TYPE:-cpx32}"
+SERVER_TYPE="${SERVER_TYPE:-cpx32}"                 # use cpx22/cpx32/cpx42 for 5/20/30 teams
 SERVER_IMAGE="${SERVER_IMAGE:-ubuntu-24.04}"
 SERVER_LOCATION="${SERVER_LOCATION:-nbg1}"          # Nuremberg
 SSH_KEY_NAME="${SSH_KEY_NAME:-${SERVER_NAME}-key}"
 FIREWALL_NAME="${FIREWALL_NAME:-${SERVER_NAME}-fw}"
 K3S_CHANNEL="${K3S_CHANNEL:-stable}"
-MAX_INSTANCES="${MAX_INSTANCES:-20}"                # team cap; raise together with SERVER_TYPE
+MAX_INSTANCES="${MAX_INSTANCES:-20}"                # use 5/20/30 with cpx22/cpx32/cpx42 VMs
 LE_SERVER="${LE_SERVER:-https://acme-v02.api.letsencrypt.org/directory}"
 STATE_DIR="${STATE_DIR:-$(pwd)/.multi-juicer-hetzner}"
 KUBECONFIG_FILE="${STATE_DIR}/kubeconfig.yaml"

--- a/guides/hetzner/setup.sh
+++ b/guides/hetzner/setup.sh
@@ -35,7 +35,7 @@
 #                       so the JuiceShop chatbot works for all teams while the
 #                       real API key stays inside the cluster.
 #   - env LLM_MODEL     Model identifier to expose to JuiceShop
-#                       (default: qwen/qwen3.5-9b).
+#                       (default: inclusionai/ling-3.0-flash-fin:free).
 #   - env LLM_API_URL   Upstream base URL, including path prefix
 #                       (default: https://openrouter.ai/api/v1).
 
@@ -53,7 +53,7 @@ REPLICAS="${REPLICAS:-2}"                           # >=2 balancer replicas for 
 
 # Optional LLM gateway (see guides/llm/llm.md). Only enabled when LLM_API_KEY is set.
 LLM_API_KEY="${LLM_API_KEY:-}"
-LLM_MODEL="${LLM_MODEL:-qwen/qwen3.5-9b}"
+LLM_MODEL="${LLM_MODEL:-inclusionai/ling-3.0-flash-fin:free}"
 LLM_API_URL="${LLM_API_URL:-https://openrouter.ai/api/v1}"
 LLM_SECRET_NAME="${LLM_SECRET_NAME:-multi-juicer-llm}"
 

--- a/guides/hetzner/setup.sh
+++ b/guides/hetzner/setup.sh
@@ -48,8 +48,9 @@ export KUBECONFIG="${KUBECONFIG_FILE}"
 mkdir -p "${STATE_DIR}"
 chmod 700 "${STATE_DIR}"
 
-log()  { printf '\n\033[1;32m==> %s\033[0m\n' "$*"; }
-warn() { printf '\n\033[1;33m!!  %s\033[0m\n' "$*" >&2; }
+log()    { printf '\n\033[1;32m==> %s\033[0m\n' "$*"; }
+warn()   { printf '\n\033[1;33m!!  %s\033[0m\n' "$*" >&2; }
+action() { printf '\n\033[1;36m>>  %s\033[0m\n' "$*"; }
 
 ############################
 # 0. Sanity checks
@@ -149,10 +150,13 @@ dns_lookup_a() {
     | jq -r '.Answer // [] | map(select(.type==1)) | .[].data' 2>/dev/null
 }
 
-cat <<EOF
-
-----------------------------------------------------------------------
-Create an A record at your DNS provider before continuing:
+log "Checking DNS for ${DOMAIN}"
+CURRENT_IPS="$(dns_lookup_a || true)"
+if echo "${CURRENT_IPS}" | grep -qx "${SERVER_IP}"; then
+  log "DNS OK: ${DOMAIN} -> ${SERVER_IP}"
+else
+  action "Action required: create an A record at your DNS provider"
+  cat <<EOF
 
     Host / Name:  ${DOMAIN}
     Type:         A
@@ -161,25 +165,25 @@ Create an A record at your DNS provider before continuing:
 
 The script will now poll public DNS every 10 s until ${DOMAIN}
 resolves to ${SERVER_IP}. Press Ctrl+C to abort.
-----------------------------------------------------------------------
 EOF
 
-DNS_TIMEOUT="${DNS_TIMEOUT:-1800}"   # 30 minutes
-SECONDS=0
-while :; do
-  CURRENT_IPS="$(dns_lookup_a || true)"
-  if echo "${CURRENT_IPS}" | grep -qx "${SERVER_IP}"; then
-    log "DNS OK: ${DOMAIN} -> ${SERVER_IP}"
-    break
-  fi
-  if (( SECONDS >= DNS_TIMEOUT )); then
-    echo "DNS did not propagate within ${DNS_TIMEOUT}s. ${DOMAIN} currently resolves to: ${CURRENT_IPS:-<nothing>}" >&2
-    echo "Re-run this script once the A record is in place — it is idempotent." >&2
-    exit 1
-  fi
-  printf '.'
-  sleep 10
-done
+  DNS_TIMEOUT="${DNS_TIMEOUT:-1800}"   # 30 minutes
+  SECONDS=0
+  while :; do
+    CURRENT_IPS="$(dns_lookup_a || true)"
+    if echo "${CURRENT_IPS}" | grep -qx "${SERVER_IP}"; then
+      log "DNS OK: ${DOMAIN} -> ${SERVER_IP}"
+      break
+    fi
+    if (( SECONDS >= DNS_TIMEOUT )); then
+      echo "DNS did not propagate within ${DNS_TIMEOUT}s. ${DOMAIN} currently resolves to: ${CURRENT_IPS:-<nothing>}" >&2
+      echo "Re-run this script once the A record is in place — it is idempotent." >&2
+      exit 1
+    fi
+    printf '.'
+    sleep 10
+  done
+fi
 
 ############################
 # 5. Wait for SSH to be ready
@@ -191,6 +195,7 @@ for i in {1..60}; do
          "root@${SERVER_IP}" 'true' 2>/dev/null; then
     break
   fi
+  printf '.'
   sleep 5
 done
 

--- a/guides/hetzner/setup.sh
+++ b/guides/hetzner/setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Provision a fresh MultiJuicer cluster on Hetzner Cloud, sized for ~10 teams.
+# Provision a fresh MultiJuicer cluster on Hetzner Cloud, sized for ~30 teams.
 #
 # The script creates a single Hetzner Cloud VM, installs k3s on it, deploys
 # ingress-nginx + cert-manager, installs MultiJuicer via Helm, and requests
@@ -57,17 +57,17 @@ LLM_MODEL="${LLM_MODEL:-inclusionai/ling-3.0-flash-fin:free}"
 LLM_API_URL="${LLM_API_URL:-https://openrouter.ai/api/v1}"
 LLM_SECRET_NAME="${LLM_SECRET_NAME:-multi-juicer-llm}"
 
-# Server / cluster sizing. cpx22 = 2 vCPU / 4 GB RAM / 40 GB SSD.
+# Server / cluster sizing. cpx32 = 4 vCPU / 8 GB RAM / 80 GB SSD (Hetzner's newer AMD generation).
 # CPU is the tightest resource — see the sizing notes in hetzner.md for the math.
-# Bump to cpx31 / cpx41 (and raise MAX_INSTANCES accordingly) for larger events.
+# Drop to cpx22 for tiny events, or bump to cpx42 / cpx52 (and raise MAX_INSTANCES accordingly) for larger ones.
 SERVER_NAME="${SERVER_NAME:-multi-juicer}"
-SERVER_TYPE="${SERVER_TYPE:-cpx22}"
+SERVER_TYPE="${SERVER_TYPE:-cpx32}"
 SERVER_IMAGE="${SERVER_IMAGE:-ubuntu-24.04}"
 SERVER_LOCATION="${SERVER_LOCATION:-nbg1}"          # Nuremberg
 SSH_KEY_NAME="${SSH_KEY_NAME:-${SERVER_NAME}-key}"
 FIREWALL_NAME="${FIREWALL_NAME:-${SERVER_NAME}-fw}"
 K3S_CHANNEL="${K3S_CHANNEL:-stable}"
-MAX_INSTANCES="${MAX_INSTANCES:-10}"                # allowed team count (fits a cpx22; raise together with SERVER_TYPE)
+MAX_INSTANCES="${MAX_INSTANCES:-30}"                # allowed team count (fits a cpx32; raise together with SERVER_TYPE)
 LE_SERVER="${LE_SERVER:-https://acme-v02.api.letsencrypt.org/directory}"
 STATE_DIR="${STATE_DIR:-$(pwd)/.multi-juicer-hetzner}"
 KUBECONFIG_FILE="${STATE_DIR}/kubeconfig.yaml"

--- a/guides/hetzner/setup.sh
+++ b/guides/hetzner/setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Provision a fresh MultiJuicer cluster on Hetzner Cloud, sized for ~30 teams.
+# Provision a fresh MultiJuicer cluster on Hetzner Cloud, sized for ~20 teams.
 #
 # The script creates a single Hetzner Cloud VM, installs k3s on it, deploys
 # ingress-nginx + cert-manager, installs MultiJuicer via Helm, and requests
@@ -67,7 +67,7 @@ SERVER_LOCATION="${SERVER_LOCATION:-nbg1}"          # Nuremberg
 SSH_KEY_NAME="${SSH_KEY_NAME:-${SERVER_NAME}-key}"
 FIREWALL_NAME="${FIREWALL_NAME:-${SERVER_NAME}-fw}"
 K3S_CHANNEL="${K3S_CHANNEL:-stable}"
-MAX_INSTANCES="${MAX_INSTANCES:-30}"                # allowed team count (fits a cpx32; raise together with SERVER_TYPE)
+MAX_INSTANCES="${MAX_INSTANCES:-20}"                # allowed team count (fits a cpx32; raise together with SERVER_TYPE)
 LE_SERVER="${LE_SERVER:-https://acme-v02.api.letsencrypt.org/directory}"
 STATE_DIR="${STATE_DIR:-$(pwd)/.multi-juicer-hetzner}"
 KUBECONFIG_FILE="${STATE_DIR}/kubeconfig.yaml"

--- a/guides/hetzner/setup.sh
+++ b/guides/hetzner/setup.sh
@@ -1,42 +1,13 @@
 #!/usr/bin/env bash
 #
-# Provision a fresh MultiJuicer cluster on Hetzner Cloud, sized for ~20 teams.
+# Provision a throw-away MultiJuicer cluster on Hetzner Cloud (~20 teams):
+# one VM, k3s + bundled Traefik with ACME (Let's Encrypt), MultiJuicer via Helm.
+# The DNS A record for DOMAIN is managed by you; the script waits for it to
+# resolve to the new VM before continuing. See hetzner.md for full details.
 #
-# The script creates a single Hetzner Cloud VM, installs k3s on it (with the
-# bundled Traefik ingress controller), configures Traefik's built-in ACME
-# client to request a Let's Encrypt certificate, and installs MultiJuicer via
-# Helm so the balancer UI is reachable over HTTPS on your own domain.
-#
-# The domain is expected to be managed at *your* DNS provider (e.g. Strato,
-# GoDaddy, Namecheap, Cloudflare, ...). This script does NOT touch your DNS
-# zone. After creating the VM, it prints the VM's public IPv4 and then
-# waits until your domain's A record resolves to that IP before continuing
-# with the k3s / ingress / Let's Encrypt part.
-#
-# The setup is intentionally "throw-away": run this before your event,
-# run `teardown.sh` afterwards, and every Hetzner resource created here
-# is gone.
-#
-# Prerequisites (see hetzner.md):
-#   - hcloud  (https://github.com/hetznercloud/cli)
-#   - kubectl (https://kubernetes.io/docs/tasks/tools/)
-#   - helm    (https://helm.sh)
-#   - ssh, ssh-keygen, curl, jq
-#   - A Hetzner Cloud API token   -> env HCLOUD_TOKEN
-#   - A domain you control        -> env DOMAIN   (e.g. juicy.example.com)
-#     (the A record for it will be   env EMAIL    (used for Let's Encrypt)
-#      created manually at your
-#      registrar, e.g. Strato)
-#
-# Optional (for AI / LLM challenges — see guides/llm/llm.md):
-#   - env LLM_API_KEY   API key of an OpenAI-compatible LLM provider.
-#                       When set, MultiJuicer's built-in LLM gateway is enabled
-#                       so the JuiceShop chatbot works for all teams while the
-#                       real API key stays inside the cluster.
-#   - env LLM_MODEL     Model identifier to expose to JuiceShop
-#                       (default: inclusionai/ling-3.0-flash-fin:free).
-#   - env LLM_API_URL   Upstream base URL, including path prefix
-#                       (default: https://openrouter.ai/api/v1).
+# Required env: HCLOUD_TOKEN, DOMAIN, EMAIL
+# Optional env (LLM gateway, see guides/llm/llm.md): LLM_API_KEY, LLM_MODEL, LLM_API_URL
+# Required binaries: hcloud, kubectl, helm, ssh, ssh-keygen, curl, jq
 
 set -euo pipefail
 
@@ -47,17 +18,16 @@ set -euo pipefail
 : "${DOMAIN:?DOMAIN is required, e.g. juicy.example.com (managed at your DNS provider)}"
 : "${EMAIL:?EMAIL is required (used for Lets Encrypt registration)}"
 
-# Production-hardening defaults (see guides/production-notes/production-notes.md).
-REPLICAS="${REPLICAS:-2}"                           # >=2 balancer replicas for pod-crash / upgrade resilience
+# See guides/production-notes/production-notes.md.
+REPLICAS="${REPLICAS:-2}"                           # >=2 for pod-crash / upgrade resilience
 
-# Optional LLM gateway (see guides/llm/llm.md). Only enabled when LLM_API_KEY is set.
+# LLM gateway (guides/llm/llm.md); enabled only when LLM_API_KEY is set.
 LLM_API_KEY="${LLM_API_KEY:-}"
 LLM_MODEL="${LLM_MODEL:-inclusionai/ling-3.0-flash-fin:free}"
 LLM_API_URL="${LLM_API_URL:-https://openrouter.ai/api/v1}"
 LLM_SECRET_NAME="${LLM_SECRET_NAME:-multi-juicer-llm}"
 
-# Server / cluster sizing. cpx32 = 4 vCPU / 8 GB RAM / 80 GB SSD (Hetzner's newer AMD generation).
-# Drop to cpx22 for tiny events, or bump to cpx42 / cpx52 (and raise MAX_INSTANCES accordingly) for larger ones.
+# cpx32 = 4 vCPU / 8 GB RAM / 80 GB SSD. Bump SERVER_TYPE + MAX_INSTANCES for larger events.
 SERVER_NAME="${SERVER_NAME:-multi-juicer}"
 SERVER_TYPE="${SERVER_TYPE:-cpx32}"
 SERVER_IMAGE="${SERVER_IMAGE:-ubuntu-24.04}"
@@ -65,7 +35,7 @@ SERVER_LOCATION="${SERVER_LOCATION:-nbg1}"          # Nuremberg
 SSH_KEY_NAME="${SSH_KEY_NAME:-${SERVER_NAME}-key}"
 FIREWALL_NAME="${FIREWALL_NAME:-${SERVER_NAME}-fw}"
 K3S_CHANNEL="${K3S_CHANNEL:-stable}"
-MAX_INSTANCES="${MAX_INSTANCES:-20}"                # allowed team count (fits a cpx32; raise together with SERVER_TYPE)
+MAX_INSTANCES="${MAX_INSTANCES:-20}"                # team cap; raise together with SERVER_TYPE
 LE_SERVER="${LE_SERVER:-https://acme-v02.api.letsencrypt.org/directory}"
 STATE_DIR="${STATE_DIR:-$(pwd)/.multi-juicer-hetzner}"
 KUBECONFIG_FILE="${STATE_DIR}/kubeconfig.yaml"
@@ -102,13 +72,10 @@ if ! hcloud ssh-key describe "${SSH_KEY_NAME}" >/dev/null 2>&1; then
 fi
 
 ############################
-# 2. Firewall (22 SSH, 80/443 HTTP(S), 6443 k8s API restricted to your IP)
+# 2. Firewall (22, 80/443 world; 6443 k8s API restricted to ADMIN_CIDR)
 ############################
-# The k3s API server listens on tcp/6443. kubectl / helm on your machine
-# need to reach it, so we open that port on the Hetzner firewall — but only
-# for *your* current public IP (a /32) so the API is not world-exposed.
-# Override ADMIN_CIDR (e.g. `1.2.3.0/24`) if you are behind a shared/dynamic
-# egress or want to allow a company range.
+# ADMIN_CIDR defaults to your current public IP /32. Override for a shared
+# egress or company range (e.g. ADMIN_CIDR=1.2.3.0/24).
 ADMIN_CIDR="${ADMIN_CIDR:-}"
 if [[ -z "${ADMIN_CIDR}" ]]; then
   MY_IP="$(curl -sS https://api.ipify.org 2>/dev/null || true)"
@@ -124,11 +91,8 @@ if ! hcloud firewall describe "${FIREWALL_NAME}" >/dev/null 2>&1; then
   hcloud firewall create --name "${FIREWALL_NAME}" >/dev/null
 fi
 
-# Merge the (possibly new) ADMIN_CIDR into the firewall's existing 6443 allowlist
-# instead of replacing it. This lets you re-run setup.sh from a new location
-# (different public IP — e.g. home vs. hotel/venue) and *add* your current IP
-# while keeping the previously-allowed ones. Set ADMIN_CIDR_RESET=1 to instead
-# drop all previous entries and keep only the current ADMIN_CIDR.
+# Merge current ADMIN_CIDR into the existing 6443 allowlist so re-runs from a
+# different location keep previous IPs. ADMIN_CIDR_RESET=1 replaces instead.
 ADMIN_CIDR_RESET="${ADMIN_CIDR_RESET:-0}"
 EXISTING_ADMIN_CIDRS=""
 if [[ "${ADMIN_CIDR_RESET}" != "1" ]]; then
@@ -178,8 +142,7 @@ log "Server public IPv4: ${SERVER_IP}"
 ############################
 # 4. Wait until the user's DNS A record points to this VM
 ############################
-# Uses Cloudflare's DNS-over-HTTPS (1.1.1.1) resolver so we bypass any local
-# DNS caches. curl + jq are already required by the script.
+# DoH via 1.1.1.1 to bypass local DNS caches.
 dns_lookup_a() {
   curl -sS -H 'accept: application/dns-json' \
     "https://cloudflare-dns.com/dns-query?name=${DOMAIN}&type=A" \
@@ -254,16 +217,10 @@ kubectl wait --for=condition=Ready node --all --timeout=180s
 ############################
 # 7. Configure Traefik with Let's Encrypt (built-in ACME)
 ############################
-# k3s installs Traefik via helm-controller from a HelmChart CR in kube-system.
-# A HelmChartConfig with the same name/namespace layers extra values on top of
-# the bundled chart's defaults — we use it to add a persistent volume for
-# acme.json (so certs survive Traefik pod restarts) and an HTTP-01
-# certResolver named 'letsencrypt'. Individual ingresses opt in via the
-# `traefik.ingress.kubernetes.io/router.tls.certresolver` annotation (§10).
-#
-# No custom init container is needed: the Traefik chart's default
-# podSecurityContext (fsGroup=65532) makes the kubelet chown the mounted PVC
-# so the non-root Traefik process can write acme.json.
+# Layer extra values onto k3s's bundled Traefik chart via HelmChartConfig:
+# a PVC for acme.json (so certs survive pod restarts) and an HTTP-01
+# certResolver 'letsencrypt'. Ingresses opt in via the router.tls.certresolver
+# annotation (§10). The chart's default fsGroup=65532 handles PVC ownership.
 log "Configuring Traefik with a Let's Encrypt certResolver"
 kubectl apply -f - <<EOF
 apiVersion: helm.cattle.io/v1
@@ -289,14 +246,9 @@ spec:
             entryPoint: web
 EOF
 
-# helm-controller reconciles the HelmChartConfig by (re-)rendering the bundled
-# Traefik chart via a Helm install/upgrade Job in kube-system, which then
-# creates/updates the Traefik Deployment. On a fresh k3s install that Job may
-# not have finished yet at this point, so the Deployment doesn't exist and
-# `kubectl wait` / `rollout status` immediately fail with NotFound. Poll for
-# the Deployment to appear first — but also detect a failing helm-install Job
-# (bad valuesContent, chart schema mismatch, ...) and surface its logs
-# instead of hanging silently until the timeout.
+# On a fresh k3s the helm-install-traefik Job may not have created the
+# Deployment yet, so poll for it before waiting. Also short-circuit on a
+# failing helm-install pod so we surface its logs instead of hanging.
 log "Waiting for Traefik to reconcile with the new configuration"
 TRAEFIK_READY=0
 for i in {1..60}; do
@@ -304,8 +256,7 @@ for i in {1..60}; do
     TRAEFIK_READY=1
     break
   fi
-  # If any helm-install-traefik* pod is CrashLoopBackOff / Error, the install
-  # is broken and no amount of waiting will help — dump its logs and bail out.
+  # Fail fast if the helm-install pod is broken.
   FAILING_POD="$(kubectl -n kube-system get pods \
     -l 'helmcharts.helm.cattle.io/chart=traefik' \
     -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.containerStatuses[*].state.waiting.reason}{"\n"}{end}' 2>/dev/null \
@@ -327,15 +278,12 @@ kubectl -n kube-system wait --for=condition=Available deploy/traefik --timeout=2
 kubectl -n kube-system rollout status deploy/traefik --timeout=240s
 
 ############################
-# 8. Cookie parser secret (persistent across re-runs — otherwise every
-#    `helm upgrade` rotates it and invalidates all team sessions)
+# 8. Cookie parser secret (persisted so helm upgrades don't invalidate sessions)
 ############################
 if [[ ! -s "${COOKIE_SECRET_FILE}" ]]; then
   log "Generating persistent cookieParserSecret at ${COOKIE_SECRET_FILE}"
-  # 24 alphanumeric chars, matches the recommendation in production-notes.md.
-  # `head -c 24` closes the pipe early, which sends SIGPIPE to `tr` (exit 141);
-  # under `set -o pipefail` that fails the whole pipeline and aborts the script,
-  # so temporarily disable pipefail just for this one pipeline.
+  # 24 alphanumeric chars (see production-notes.md). Disable pipefail: `head`
+  # closes the pipe early, sending SIGPIPE to `tr` which would abort the script.
   set +o pipefail
   LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 24 > "${COOKIE_SECRET_FILE}"
   set -o pipefail
@@ -349,8 +297,7 @@ COOKIE_PARSER_SECRET="$(cat "${COOKIE_SECRET_FILE}")"
 HELM_LLM_ARGS=()
 if [[ -n "${LLM_API_KEY}" ]]; then
   log "Configuring LLM gateway (model=${LLM_MODEL}, apiUrl=${LLM_API_URL})"
-  # Upsert the k8s secret with the upstream API key. `kubectl apply` avoids
-  # errors on re-runs and lets the user rotate the key by re-running setup.sh.
+  # Upsert secret so re-runs can rotate the key.
   kubectl create secret generic "${LLM_SECRET_NAME}" \
     --namespace default \
     --from-literal=token="${LLM_API_KEY}" \

--- a/guides/hetzner/setup.sh
+++ b/guides/hetzner/setup.sh
@@ -149,6 +149,32 @@ dns_lookup_a() {
     | jq -r '.Answer // [] | map(select(.type==1)) | .[].data' 2>/dev/null
 }
 
+# Report what DNS currently returns, but only when the answer changes, so the
+# poll below stays quiet while nothing moves. The first time we see a wrong
+# (rather than missing) answer, point at Cloudflare's cache purge tool: a stale
+# entry there — e.g. from a wildcard record with a long TTL — keeps 1.1.1.1 on
+# the old IP long after the A record itself is correct.
+LAST_REPORTED_IPS="__unset__"
+PURGE_HINT_SHOWN=0
+report_dns() {
+  local ips="${1//$'\n'/, }"
+  [[ "${ips}" == "${LAST_REPORTED_IPS}" ]] && return 0
+  LAST_REPORTED_IPS="${ips}"
+  warn "${DOMAIN} resolves to ${ips:-<nothing>}, expected ${SERVER_IP}"
+  if [[ -n "${ips}" && "${PURGE_HINT_SHOWN}" == "0" ]]; then
+    PURGE_HINT_SHOWN=1
+    cat >&2 <<EOF
+
+    If the A record is already in place, the resolver this script queries
+    (1.1.1.1) is likely still serving a cached older answer. Purge it at
+    https://one.one.one.one/purge-cache/ (name: ${DOMAIN}, type: A) or run:
+
+      curl -sSL -X POST "https://cloudflare-dns.com/api/v1/purge?domain=${DOMAIN}&type=A"
+
+EOF
+  fi
+}
+
 log "Checking DNS for ${DOMAIN}"
 CURRENT_IPS="$(dns_lookup_a || true)"
 if echo "${CURRENT_IPS}" | grep -qx "${SERVER_IP}"; then
@@ -166,6 +192,8 @@ The script will now poll public DNS every 10 s until ${DOMAIN}
 resolves to ${SERVER_IP}. Press Ctrl+C to abort.
 EOF
 
+  report_dns "${CURRENT_IPS}"
+
   DNS_TIMEOUT="${DNS_TIMEOUT:-1800}"   # 30 minutes
   SECONDS=0
   while :; do
@@ -179,6 +207,7 @@ EOF
       echo "Re-run this script once the A record is in place — it is idempotent." >&2
       exit 1
     fi
+    report_dns "${CURRENT_IPS}"
     printf '.'
     sleep 10
   done

--- a/guides/hetzner/setup.sh
+++ b/guides/hetzner/setup.sh
@@ -304,6 +304,59 @@ COOKIE_PARSER_SECRET="$(cat "${COOKIE_SECRET_FILE}")"
 ############################
 # 10. Optional: LLM gateway secret (for AI / chatbot challenges)
 ############################
+# Preflight: verify the Hetzner VM (and therefore the in-cluster LLM gateway,
+# which egresses through the same host via k3s SNAT/MASQUERADE) can actually
+# reach the LLM provider. Hetzner Cloud firewalls only filter *inbound*
+# traffic by default, so this is a smoke test aimed at catching provider-side
+# issues (geoblocking, rate limits, DNS, wrong URL) or a locked-down network
+# on custom images. Failures here are warnings, never fatal — the rest of
+# the MultiJuicer install is unaffected.
+#
+# When LLM_API_KEY is set we additionally list the provider's model catalog
+# and warn if LLM_MODEL is not in it (common cause of "AI challenges hang
+# then time out" — the request is accepted but the upstream 4xx's on the
+# missing model, and JuiceShop retries until it gives up).
+LLM_BASE="${LLM_API_URL%/}"
+LLM_HOST="$(printf '%s' "${LLM_API_URL}" | awk -F/ '{print $3}')"
+LLM_REACHABLE=0
+LLM_MODEL_OK=0
+log "Checking outbound connectivity from the Hetzner VM to ${LLM_HOST} (${LLM_BASE}/models)"
+# `-m 15`: 15 s wall-clock ceiling. `-o /dev/null -w '%{http_code}'` prints
+# just the HTTP status (or `000` on connect/timeout failure). We accept
+# anything 2xx-4xx as "network path works" — auth/model issues are handled
+# by the follow-up check below.
+LLM_CODE="$($SSH "curl -sS -o /dev/null -m 15 -w '%{http_code}' '${LLM_BASE}/models' 2>/dev/null || true" </dev/null || true)"
+case "${LLM_CODE}" in
+  2*|3*|4*)
+    log "LLM API reachable from the Hetzner VM (HTTP ${LLM_CODE})"
+    LLM_REACHABLE=1
+    ;;
+  *)
+    warn "LLM API ${LLM_BASE}/models is NOT reachable from the Hetzner VM (curl result: '${LLM_CODE:-<no response>}')."
+    warn "Hetzner Cloud allows all outbound traffic by default, so this is almost always an upstream issue"
+    warn "(provider outage, DNS, geoblock, or wrong LLM_API_URL). Continuing anyway — the JuiceShop chatbot"
+    warn "and AI challenges will fail until you fix the upstream. You can test manually with:"
+    warn "  ssh -i ${SSH_KEY_FILE} root@${SERVER_IP} \"curl -v ${LLM_BASE}/models\""
+    ;;
+esac
+
+if [[ -n "${LLM_API_KEY}" && "${LLM_REACHABLE}" -eq 1 ]]; then
+  log "Checking model '${LLM_MODEL}' is served by ${LLM_HOST}"
+  # Passes the key via env to avoid it landing in the remote shell history or
+  # `ps` output on the VM.
+  LLM_MODELS_JSON="$($SSH "LLM_API_KEY='${LLM_API_KEY}' curl -sS -m 20 -H 'Authorization: Bearer '\"\$LLM_API_KEY\" '${LLM_BASE}/models' 2>/dev/null || true" </dev/null || true)"
+  if printf '%s' "${LLM_MODELS_JSON}" | jq -e --arg m "${LLM_MODEL}" '(.data // .models // []) | map(.id // .name) | index($m)' >/dev/null 2>&1; then
+    log "Model '${LLM_MODEL}' is available"
+    LLM_MODEL_OK=1
+  else
+    warn "Model '${LLM_MODEL}' was NOT returned by ${LLM_BASE}/models."
+    warn "Either the model id is wrong or your account cannot access it — JuiceShop AI challenges"
+    warn "will hang and eventually error out on the first chatbot request. Pick another model"
+    warn "(see your provider dashboard, e.g. https://openrouter.ai/models) and re-run with:"
+    warn "  LLM_MODEL='<other-model>' ./setup.sh"
+  fi
+fi
+
 HELM_LLM_ARGS=()
 if [[ -n "${LLM_API_KEY}" ]]; then
   log "Configuring LLM gateway (model=${LLM_MODEL}, apiUrl=${LLM_API_URL})"
@@ -355,6 +408,11 @@ ADMIN_PW="$(kubectl get secret multi-juicer-secret -o jsonpath='{.data.adminPass
 LLM_STATUS="disabled (JuiceShop chatbot / AI challenges will not work)"
 if [[ -n "${LLM_API_KEY}" ]]; then
   LLM_STATUS="enabled — model=${LLM_MODEL}, upstream=${LLM_API_URL}"
+  if [[ "${LLM_REACHABLE}" -ne 1 ]]; then
+    LLM_STATUS="${LLM_STATUS} (WARNING: upstream not reachable from the VM — see warnings above)"
+  elif [[ "${LLM_MODEL_OK}" -ne 1 ]]; then
+    LLM_STATUS="${LLM_STATUS} (WARNING: model not listed by provider — see warnings above)"
+  fi
 fi
 
 cat <<EOF

--- a/guides/hetzner/setup.sh
+++ b/guides/hetzner/setup.sh
@@ -371,9 +371,11 @@ $(log "MultiJuicer is ready")
 The Let's Encrypt certificate is issued by Traefik on the first HTTPS request
 and can take up to a minute. If the browser initially shows Traefik's default
 self-signed certificate, wait a moment and reload.
+EOF
 
-When your event is over, run ./teardown.sh to delete every Hetzner
-resource (server, firewall, SSH key) created by this script. The A
-record for ${DOMAIN} at your DNS provider is *not* touched — remove
-it there manually if you no longer need it.
+action "After the event: run ./teardown.sh to delete every Hetzner resource (server, firewall, SSH key) created by this script"
+cat <<EOF
+
+  The A record for ${DOMAIN} at your DNS provider is *not* touched — remove it there
+  manually if you no longer need it.
 EOF

--- a/guides/hetzner/teardown.sh
+++ b/guides/hetzner/teardown.sh
@@ -1,17 +1,10 @@
 #!/usr/bin/env bash
 #
-# Delete every Hetzner resource created by ./setup.sh:
-#   - Hetzner Cloud server
-#   - Hetzner Cloud firewall
-#   - Hetzner Cloud SSH key
-#   - Local state directory (kubeconfig, SSH key)
+# Delete every Hetzner resource created by ./setup.sh (server, firewall, SSH
+# key) and wipe the local state dir. The DNS A record at your provider is NOT
+# touched — remove it manually.
 #
-# The DNS A record for your domain is managed at your own DNS provider
-# (e.g. Strato) and is *not* touched by this script — remove it there
-# manually once you no longer need the deployment.
-#
-# Required env vars (same as setup.sh):
-#   HCLOUD_TOKEN
+# Required env: HCLOUD_TOKEN
 
 set -euo pipefail
 

--- a/guides/hetzner/teardown.sh
+++ b/guides/hetzner/teardown.sh
@@ -53,4 +53,4 @@ if [[ -d "${STATE_DIR}" ]]; then
 fi
 
 log "Teardown complete."
-log "Reminder: remove the A record for your domain at your DNS provider (e.g. Strato) if you no longer need it."
+log "Reminder: remove the A record for your domain at your DNS provider if you no longer need it."

--- a/guides/hetzner/teardown.sh
+++ b/guides/hetzner/teardown.sh
@@ -17,7 +17,8 @@ STATE_DIR="${STATE_DIR:-$(pwd)/.multi-juicer-hetzner}"
 
 export HCLOUD_TOKEN
 
-log() { printf '\n\033[1;33m==> %s\033[0m\n' "$*"; }
+log() { printf '\n\033[1;32m==> %s\033[0m\n' "$*"; }
+action() { printf '\n\033[1;36m>>  %s\033[0m\n' "$*"; }
 
 for bin in hcloud; do
   command -v "$bin" >/dev/null 2>&1 || { echo "Missing required binary: $bin" >&2; exit 1; }
@@ -46,4 +47,4 @@ if [[ -d "${STATE_DIR}" ]]; then
 fi
 
 log "Teardown complete."
-log "Reminder: remove the A record for your domain at your DNS provider if you no longer need it."
+action "Reminder: remove the A record for your domain at your DNS provider if you no longer need it."

--- a/guides/hetzner/teardown.sh
+++ b/guides/hetzner/teardown.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Delete every Hetzner resource created by ./setup.sh:
+#   - Hetzner Cloud server
+#   - Hetzner Cloud firewall
+#   - Hetzner Cloud SSH key
+#   - Local state directory (kubeconfig, SSH key)
+#
+# The DNS A record for your domain is managed at your own DNS provider
+# (e.g. Strato) and is *not* touched by this script — remove it there
+# manually once you no longer need the deployment.
+#
+# Required env vars (same as setup.sh):
+#   HCLOUD_TOKEN
+
+set -euo pipefail
+
+: "${HCLOUD_TOKEN:?HCLOUD_TOKEN is required}"
+
+SERVER_NAME="${SERVER_NAME:-multi-juicer}"
+SSH_KEY_NAME="${SSH_KEY_NAME:-${SERVER_NAME}-key}"
+FIREWALL_NAME="${FIREWALL_NAME:-${SERVER_NAME}-fw}"
+STATE_DIR="${STATE_DIR:-$(pwd)/.multi-juicer-hetzner}"
+
+export HCLOUD_TOKEN
+
+log() { printf '\n\033[1;33m==> %s\033[0m\n' "$*"; }
+
+for bin in hcloud; do
+  command -v "$bin" >/dev/null 2>&1 || { echo "Missing required binary: $bin" >&2; exit 1; }
+done
+
+# --- Hetzner Cloud resources ---
+if hcloud server describe "${SERVER_NAME}" >/dev/null 2>&1; then
+  log "Deleting server '${SERVER_NAME}'"
+  hcloud server delete "${SERVER_NAME}" >/dev/null
+fi
+
+if hcloud firewall describe "${FIREWALL_NAME}" >/dev/null 2>&1; then
+  log "Deleting firewall '${FIREWALL_NAME}'"
+  hcloud firewall delete "${FIREWALL_NAME}" >/dev/null
+fi
+
+if hcloud ssh-key describe "${SSH_KEY_NAME}" >/dev/null 2>&1; then
+  log "Deleting SSH key '${SSH_KEY_NAME}'"
+  hcloud ssh-key delete "${SSH_KEY_NAME}" >/dev/null
+fi
+
+# --- Local state ---
+if [[ -d "${STATE_DIR}" ]]; then
+  log "Removing local state at ${STATE_DIR}"
+  rm -rf "${STATE_DIR}"
+fi
+
+log "Teardown complete."
+log "Reminder: remove the A record for your domain at your DNS provider (e.g. Strato) if you no longer need it."

--- a/guides/hetzner/teardown.sh
+++ b/guides/hetzner/teardown.sh
@@ -47,4 +47,4 @@ if [[ -d "${STATE_DIR}" ]]; then
 fi
 
 log "Teardown complete."
-action "Reminder: remove the A record for your domain at your DNS provider if you no longer need it."
+action "Reminder: the A record for your domain at your DNS provider was *not* touched — remove it there manually if you no longer need it"


### PR DESCRIPTION
### Description

**PR: Add Hetzner Cloud setup guide for MultiJuicer**

New `guides/hetzner/` provider guide, matching the style of the existing `digital-ocean` / `aws` / `azure` ones.

- **`setup.sh`** — idempotent bash script: provisions SSH key, firewall (22/80/443 world + 6443 to admin IP) and a `cpx32` VM via `hcloud`; waits for the user's external A record to resolve; installs k3s (Traefik off), ingress-nginx, cert-manager + Let's Encrypt `ClusterIssuer`; deploys MultiJuicer via Helm with `replicas=2`, persistent `cookieParserSecret`, `config.maxInstances=20`, and optional LLM gateway (`LLM_API_KEY` / `LLM_MODEL` / `LLM_API_URL`, default OpenRouter `nvidia/nemotron-3.5-lightning:free`). Prints URL + admin password on completion.
- **`teardown.sh`** — deletes server, firewall, SSH key and local state.
- **`hetzner.md`** — prerequisites, env vars, run/verify/teardown; DNS handled at the user's existing provider (no Hetzner DNS coupling); "What the script creates" overview.

**Sizing:** `cpx32` (4 vCPU / 8 GB, €0.0677/h, capped €42.23/month) → ~20 concurrent teams, validated by a staggered 30-team ramp + light API load test (`/rest/products/search`, `/api/Challenges`, `/rest/memories`); scheduler CPU-requests ceiling hit at ~19 pods while real utilization stayed ~20 % CPU / 45 % RAM.


### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [X] My contribution includes AI-generated content, as disclosed below:
    - AI Tools: `JetBrains Junie`
    - LLMs and versions: `Claude Opus 4.7`
    - Prompts: `I want to host a MultiJuicer cluster for up to 50 teams on a Cloud Server at https://www.hetzner.com/. The server has to be accessible via public Internet on its own URL via HTTPS. DNS needs to be properly assigned etc. Create a CLI script I can manually run to set this up from scratch. I intend to just delete the entire server after the event and always create a fresh one to save costs.`
